### PR TITLE
Post-INOV setcode update

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -788,9 +788,8 @@
 !setcode 0xe9 Magna Warrior
 !setcode 0xea Crystron
 !setcode 0xeb Chemical Beast
-!setcode 0x1ec Subterror
-!setcode 0x1ed SPYral
-!setcode 0x1ee Abyss
-!setcode 0x11ee Abyss Actor
-!setcode 0x21ee Abyss Script
+!setcode 0x1ed Abyss
+!setcode 0x11ed Abyss Actor
+!setcode 0x21ed Abyss Script
 !setcode 0x1ef Darklord
+!setcode 0x1f0 Subterror

--- a/strings.conf
+++ b/strings.conf
@@ -786,11 +786,11 @@
 !setcode 0xe7 Silent Swordsman
 !setcode 0xe8 Silent Magician
 !setcode 0xe9 Magna Warrior
-!setcode 0x1ea Predator Plant
-!setcode 0x1eb Crystron
-!setcode 0x1ec Chemical Beast (Kagoju)
-!setcode 0x1ed Abyss
-!setcode 0x11ed Abyss Actor
-!setcode 0x21ed Abyss Script
+!setcode 0xea Crystron
+!setcode 0xeb Chemical Beast
+!setcode 0x1ec Subterror
+!setcode 0x1ed SPYral
+!setcode 0x1ee Abyss
+!setcode 0x11ee Abyss Actor
+!setcode 0x21ee Abyss Script
 !setcode 0x1ef Darklord
-!setcode 0x1f0 Subterror


### PR DESCRIPTION
I've removed "Predator Plant" from the list: since INOV had no support specifically for them, at the moment it's just a series, not an archetype. Also, since "The Dark Illusion" comes out on August 5th and "Destiny Soldiers" on August 6th, I've changed the order of the setcodes and left a spot for the "SPYral": while they haven't been revealed yet, the TCG has always done original archetypes rather than series, so it's likely they'll need a spot as well. What do you think?