### PR TITLE
Added new setcodes from RATE

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -796,3 +796,4 @@
 !setcode 0xee SPYRAL
 !setcode 0x10ee SPYRAL GEAR
 !setcode 0xef Darklord
+!setcode 0x11f0 Pendulum Dragon

--- a/strings.conf
+++ b/strings.conf
@@ -796,4 +796,5 @@
 !setcode 0xee SPYRAL
 !setcode 0x10ee SPYRAL GEAR
 !setcode 0xef Darklord
-!setcode 0x11f0 Pendulum Dragon
+!setcode 0x1f0 Wind Witch
+!setcode 0x11f1 Pendulum Dragon

--- a/strings.conf
+++ b/strings.conf
@@ -797,4 +797,6 @@
 !setcode 0x10ee SPYRAL GEAR
 !setcode 0xef Darklord
 !setcode 0x1f0 Wind Witch
-!setcode 0x11f1 Pendulum Dragon
+!setcode 0x1f1 Pendulum Dragon
+!setcode 0x1f2 New RATE Archetype 1
+!setcode 0x1f3 New RATE Archetype 2


### PR DESCRIPTION
Now that the leaks have begun, we can already see that "Pendulum Dragon" is now going to be an official archetype. The logical step would be to put it at the first new code avaiable, but I was wondering: wouldn't it be best to put it as 0x11f? (0x11f1 at the moment) and leave 0x1f? as a super-series for cards like "Fusion Dragon", "Synchro Dragon", etc., just in case they're needed later? What do you think?