### PR TITLE
Update strings.conf

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -589,6 +589,7 @@
 !setcode 0x45 Archfiend
 !setcode 0x1045 Red Dragon Archfiend
 !setcode 0x46 Polymerization/Fusion
+!setcode 0x1046 Fusion Dragon
 !setcode 0x47 Gem-
 !setcode 0x1047 Gem-Knight
 !setcode 0x48 Number
@@ -671,6 +672,7 @@
 !setcode 0x101b Mecha Phantom Beast
 !setcode 0x84 Battlin' Boxer
 !setcode 0x1073 Chaos Xyz
+!setcode 0x2073 Xyz Dragon
 !setcode 0x1048 Number C
 !setcode 0x85 Super-Defense
 !setcode 0x86 Star Seraph
@@ -806,6 +808,4 @@
 !setcode 0xf4 Eidolon Beast
 !setcode 0x1f5 Lyrical Luscinia
 !setcode 0x1f6 True King
-!setcode 0x1f7 Xyz Dragon
-!setcode 0x1f8 Synchro Dragon
-!setcode 0x1f9 Fusion Dragon
+!setcode 0x1f7 Synchro Dragon


### PR DESCRIPTION
If we're putting them separated, shouldn't "Xyz Dragon" and "Fusion Dragon" be subarchetypes of "Xyz" and "Fusion" respectively?