### PR TITLE
fix Pendulumgraph of Ages

### DIFF
--- a/scripts/SD31-JP/c100331023.lua
+++ b/scripts/SD31-JP/c100331023.lua
@@ -38,7 +38,6 @@ function c100331023.thcfilter(c,tp)
 	return c:IsType(TYPE_PENDULUM) and c:IsPreviousSetCard(0x98)
 		and c:GetPreviousControler()==tp and c:IsPreviousPosition(POS_FACEUP)
 		and (pl==LOCATION_MZONE or (pl==LOCATION_SZONE and (ps==6 or ps==7)))
-		and not c:IsFacedown()
 end
 function c100331023.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg and eg:IsExists(c100331023.thcfilter,1,nil,tp)


### PR DESCRIPTION
Now _Pendulumgraph of Ages_ check if the cards are face-up after them leave field, e.g. return to hand. But as I know, there is no such limit for other similar cards.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19522&keyword=&tag=-1

Is there any reason i don't know?