### PR TITLE
Added "Supreme King"-related archetypes

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -812,3 +812,5 @@
 !setcode 0x1f8 Lyrical Luscinia
 !setcode 0x1f9 True King
 !setcode 0x1fa Gandora
+!setcode 0x11fb Supreme King Gate
+!setcode 0x21fb Supreme King Servant Dragon


### PR DESCRIPTION
Since the archetypes are definitely related, I thought, instead of putting them as 0x1fb and 0x1fc, we might as well save space, give them the "Abyss Actor" treatment and put them under the same 0x1fb super-archetype. What do you think?