### PR TITLE
Updated "Pendulum" archetype

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -802,14 +802,14 @@
 !setcode 0xef Darklord
 !setcode 0xf0 Wind Witch
 !setcode 0xf1 Jyuunishishi
-!setcode 0xf2 Pendulum Dragon
+!setcode 0xf2 Pendulum
+!setcode 0x10f2 Pendulum Dragon
+!setcode 0x20f2 Pendulumgraph
 !setcode 0xf3 Preda
 !setcode 0x10f3 Predaplant
 !setcode 0xf4 Eidolon Beast
 !setcode 0x1f5 Skyscraper
 !setcode 0x1f6 Synchro Dragon
-!setcode 0x1f7 Pendulum
-!setcode 0x11f7 Pendulumgraph
 !setcode 0x1f8 Lyrical Luscinia
 !setcode 0x1f9 True King
 !setcode 0x1fa Gandora


### PR DESCRIPTION
I realized just now that "Pendulum Dragon" is also a sub-archetype of "Pendulum"... -_-'
With 0xf2 as the superarchetype, we should go in chronological order: 0x10f2 is "Pendulum Dragon", 0x20f2 is "Pendulumgraph". Agreed?