### PR TITLE
Added Control Category for Subterror Behemoth Voltelluric

### DIFF
--- a/scripts/RATE-EN/c100911084.lua
+++ b/scripts/RATE-EN/c100911084.lua
@@ -4,6 +4,7 @@ function c100911084.initial_effect(c)
 	--flip
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(100911084,0))
+	e1:SetCategory(CATEGORY_CONTROL)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
 	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e1:SetCountLimit(1,100911084)


### PR DESCRIPTION
I don't know which scripts have "IsHasCategory(CATEGORY_CONTROL)", but cards like [Mind Control](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c37520316.lua#L5) and [No. 46](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c2978414.lua#L2) have it.