### PR TITLE
Added Descriptions for Survival Line

### DIFF
--- a/scripts/SR04-JP/c100304100.lua
+++ b/scripts/SR04-JP/c100304100.lua
@@ -12,7 +12,7 @@ function c100304100.initial_effect(c)
 	e1:SetTarget(c100304100.target)
 	e1:SetOperation(c100304100.activate)
 	c:RegisterEffect(e1)
-	--destory
+	--destroy
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(100304100,1))
 	e2:SetType(EFFECT_TYPE_QUICK_O)

--- a/scripts/SR04-JP/c100304100.lua
+++ b/scripts/SR04-JP/c100304100.lua
@@ -4,6 +4,7 @@
 function c100304100.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(100304100,0))
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -13,6 +14,7 @@ function c100304100.initial_effect(c)
 	c:RegisterEffect(e1)
 	--destory
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(100304100,1))
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetRange(LOCATION_GRAVE)


### PR DESCRIPTION
The first card I can think of is [Trap of Darkness](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c79766336.lua) and any other card that will copy its grave effects, so it doesn't show blank to the player.

When I used "Destiny HERO - Diamond Dude" to copy "Galaxy Cyclone" it showed blank because it also didn't have descriptions, so I added descriptions also as a precaution since they are similar situations.