### PR TITLE
New setcodes

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -826,4 +826,5 @@
 !setcode 0xfa Mythic Radiance Dragon
 !setcode 0x1fb Trickster
 !setcode 0x1fc Gouki
-!setcode 0x1fd Seihai
+!setcode 0x11fd Star Grail
+!setcode 0x21fd Star Relic


### PR DESCRIPTION
https://ygorganization.com/seek-the-grail/

Since "Star Grail Swordsman Aurum" confirmed the existance of a "Star Relic" archetype, do you think we should deal with them like with the "Noble Knight"/"Noble Arms" and "Abyss Actor"/"Abyss Script" archetypes, treating them as subarchetypes of a "Star" superarchetype? Or is it better to leave "Star Grail" as 0x1fd and put "Star Relic" as 0x1fe?