### PR TITLE
Added "Bonding" archetype

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -857,3 +857,4 @@
 !setcode 0xfd Star Grail
 !setcode 0xfe Star Relic
 !setcode 0xff Clear Wing
+!setcode 0x100 Bonding

--- a/strings.conf
+++ b/strings.conf
@@ -857,4 +857,4 @@
 !setcode 0xfd Star Grail
 !setcode 0xfe Star Relic
 !setcode 0xff Clear Wing
-!setcode 0x100 Bonding
+!setcode 0x200 Bonding


### PR DESCRIPTION
While 0x100 _is_ the most logical choice for the new archetype, this leads to a question that we'd best answer before the next VJump: what are we going to do with temporary archetypes from now on? Up until now, we added 0x100 to all archetype to mark them as temporary (ex. "Clear Wing" was 0x1ff before OEWD got released): what are we going to do now that we've broken the 2 digits limit? I'd rather know before the 20th's VJump, if possible: with Circuit Break being almost definitely featured in it, chances of at least 1 new archetype are high, so I'd prefer to know the new policy as soon as possible.