### PR TITLE
Fixed Odd-Eyes Lancer Dragon

### DIFF
--- a/scripts/CP17-JP/c100217001.lua
+++ b/scripts/CP17-JP/c100217001.lua
@@ -37,7 +37,7 @@ function c100217001.initial_effect(c)
 end
 function c100217001.cfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsType(TYPE_PENDULUM)
-		and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_MZONE) and (c:GetPreviousPosition()==POS_FACEUP or c:IsReason(REASON_BATTLE)) and c:GetPreviousControler()==tp
 end
 function c100217001.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c100217001.cfilter,1,nil,tp)


### PR DESCRIPTION
Q: If a face-down Defense Position Stargazer Magician on my field is destroyed by battle or card effect, can I activate the effect of an Odd-Eyes Lancer Dragon in my hand that Special Summons it?
 A: If a face-down Pendulum Monster in your Monster Zone is attacked by an opponent’s monster, flipped face-up, and destroyed, you can activate the effect of an Odd-Eyes Lancer Dragon in your hand that Special Summons it. Also, if a face-down Pendulum Monster in your Monster Zone is destroyed by a card effect such as Shield Crush, you cannot activate the effect of an Odd-Eyes Lancer Dragon in your hand that Special Summons it.