### PR TITLE
Added "Reloader Dragon"

### DIFF
--- a/scripts/VP17-JP/c100209002.lua
+++ b/scripts/VP17-JP/c100209002.lua
@@ -1,0 +1,97 @@
+--リローダー・ドラゴン
+--Reloader Dragon
+--Scripted by Eerie Code
+function c100209002.initial_effect(c)
+	c:EnableReviveLimit()
+	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x201),2,2)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(100209002,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,100209002)
+	e1:SetTarget(c100209002.sptg)
+	e1:SetOperation(c100209002.spop)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(100209002,1))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCondition(c100209002.thcon)
+	e2:SetTarget(c100209002.thtg)
+	e2:SetOperation(c100209002.thop)
+	c:RegisterEffect(e2)
+end
+function c100209002.spfilter1(c,e,tp)
+	if c:IsFaceup() and c:IsType(TYPE_LINK) then
+		local zone=c:GetLinkedZone()
+		return zone~=0 and Duel.IsExistingMatchingCard(c100209002.spfilter2,tp,LOCATION_HAND,0,1,nil,e,tp,zone)
+	else return false end
+end
+function c100209002.spfilter2(c,e,tp,zone)
+	return c:IsSetCard(0x201) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
+end
+function c100209002.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c100209002.spfilter1(chkc,e,tp) and chkc~=c end
+	if chk==0 then return Duel.IsExistingTarget(c100209002.spfilter1,tp,LOCATION_MZONE,0,1,c,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c100209002.spfilter1,tp,LOCATION_MZONE,0,1,1,c,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c100209002.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local lc=Duel.GetFirstTarget()
+	if lc:IsRelateToEffect(e) and lc:IsFaceup() then
+		local zone=lc:GetLinkedZone()
+		if zone==0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc=Duel.SelectMatchingCard(tp,c100209002.spfilter2,tp,LOCATION_HAND,0,1,1,nil,e,tp,zone):GetFirst()
+		if tc and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP,zone) then
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_CANNOT_BE_LINK_MATERIAL)
+			e1:SetValue(1)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			tc:RegisterEffect(e1,true)
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+			e2:SetRange(LOCATION_MZONE)
+			e2:SetCode(EVENT_PHASE+PHASE_END)
+			e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+			e2:SetOperation(c100209002.desop)
+			e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+			e2:SetCountLimit(1)
+			tc:RegisterEffect(e2,true)
+		end
+		Duel.SpecialSummonComplete()
+	end
+end
+function c100209002.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+end
+function c100209002.thcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:GetPreviousControler()==tp and bit.band(r,0x21)==0x21
+end
+function c100209002.thfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x201) and c:IsAbleToHand()
+end
+function c100209002.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c100209002.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c100209002.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c100209002.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c100209002.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
[Effect taken from Maxut](http://blog.livedoor.jp/maxut/archives/50346525.html):

2 "Vullet" monsters
You can target 1 other Link monster you control: Special Summon 1 "Vullet" monster from your hand to a zone that target points to, but it cannot be used as a Link Material, also it is destroyed during the End Phase. You can only use this effect of "Reloader Dragon" once per turn. If this card is destroyed by battle and sent to the GY: You can target 1 "Vullet" monster in your GY; add it to your hand.

I'll leave it as a separate branch until the Organization confirms it.