### PR TITLE
General fix for DP19

### DIFF
--- a/scripts/DP19-JP/c100407001.lua
+++ b/scripts/DP19-JP/c100407001.lua
@@ -1,57 +1,57 @@
 --ミレニアム・アイズ・イリュージョニスト
 --Millennium-Eyes Illusionist
-function c100419001.initial_effect(c)
+function c100407001.initial_effect(c)
 	--equip
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(100419001,0))
+	e1:SetDescription(aux.Stringid(100407001,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetRange(LOCATION_HAND)
-	e1:SetCountLimit(1,100419001)
-	e1:SetCost(c100419001.eqcost)
-	e1:SetTarget(c100419001.eqtg)
-	e1:SetOperation(c100419001.eqop)
+	e1:SetCountLimit(1,100407001)
+	e1:SetCost(c100407001.eqcost)
+	e1:SetTarget(c100407001.eqtg)
+	e1:SetOperation(c100407001.eqop)
 	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(100419001,1))
+	e2:SetDescription(aux.Stringid(100407001,1))
 	e2:SetCategory(CATEGORY_TOHAND)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e2:SetRange(LOCATION_GRAVE)
-	e2:SetCountLimit(1,100419001+100)
-	e2:SetCondition(c100419001.thcon)
-	e2:SetTarget(c100419001.thtg)
-	e2:SetOperation(c100419001.thop)
+	e2:SetCountLimit(1,100407001+100)
+	e2:SetCondition(c100407001.thcon)
+	e2:SetTarget(c100407001.thtg)
+	e2:SetOperation(c100407001.thop)
 	c:RegisterEffect(e2)
 end
-function c100419001.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407001.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
 end
-function c100419001.filter(c)
+function c100407001.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c:IsAbleToChangeControler()
 end
-function c100419001.eqfilter(c)
+function c100407001.eqfilter(c)
 	local m=_G["c"..c:GetCode()]
 	return c:IsFaceup() and ((c:IsSetCard(0x20a) and c:IsType(TYPE_FUSION)) or c:IsCode(64631466,63519819)) and m.CanEquipMonster(c)
 end
-function c100419001.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and c100419001.filter(chkc) and chkc~=e:GetHandler() end
+function c100407001.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c100407001.filter(chkc) and chkc~=e:GetHandler() end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c100419001.filter,tp,0,LOCATION_MZONE,1,nil)
-		and Duel.IsExistingMatchingCard(c100419001.eqfilter,tp,LOCATION_MZONE,0,1,nil) end
+		and Duel.IsExistingTarget(c100407001.filter,tp,0,LOCATION_MZONE,1,nil)
+		and Duel.IsExistingMatchingCard(c100407001.eqfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c100419001.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c100407001.filter,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
 end
-function c100419001.eqop(e,tp,eg,ep,ev,re,r,rp)
+function c100407001.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc1=Duel.GetFirstTarget()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectMatchingCard(tp,c100419001.eqfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c100407001.eqfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	local tc2=g:GetFirst()
 	if not tc2 then return end
 	local m=_G["c"..tc2:GetCode()]
@@ -59,17 +59,17 @@ function c100419001.eqop(e,tp,eg,ep,ev,re,r,rp)
 		m.EquipMonster(tc2,tp,tc1)
 	end
 end
-function c100419001.thfilter(c,e)
+function c100407001.thfilter(c,e)
 	return (c:IsSetCard(0x20a) and c:IsType(TYPE_FUSION)) or c:IsCode(64631466,63519819)
 end
-function c100419001.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c100419001.thfilter,1,nil)
+function c100407001.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c100407001.thfilter,1,nil)
 end
-function c100419001.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407001.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,e:GetHandler(),1,0,0)
 end
-function c100419001.thop(e,tp,eg,ep,ev,re,r,rp)
+function c100407001.thop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) then
 		Duel.SendtoHand(e:GetHandler(),nil,REASON_EFFECT)
 	end

--- a/scripts/DP19-JP/c100407003.lua
+++ b/scripts/DP19-JP/c100407003.lua
@@ -1,21 +1,21 @@
 --ミレニアム・アイズ・サクリファイス
 --Millennium-Eyes Restrict
-function c100419003.initial_effect(c)
+function c100407003.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCodeFun(c,64631466,aux.FilterBoolFunction(Card.IsFusionType,TYPE_EFFECT),1,true,true)
 	--Equip
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(100419003,0))
+	e1:SetDescription(aux.Stringid(100407003,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetCountLimit(1)
-	e1:SetCondition(c100419003.eqcon)
-	e1:SetTarget(c100419003.eqtg)
-	e1:SetOperation(c100419003.eqop)
+	e1:SetCondition(c100407003.eqcon)
+	e1:SetTarget(c100407003.eqtg)
+	e1:SetOperation(c100407003.eqop)
 	c:RegisterEffect(e1)
 	--atk
 	local e2=Effect.CreateEffect(c)
@@ -23,12 +23,12 @@ function c100419003.initial_effect(c)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetValue(c100419003.atkval)
+	e2:SetValue(c100407003.atkval)
 	c:RegisterEffect(e2)
 	-- def
 	local e3=e2:Clone()
 	e3:SetCode(EFFECT_UPDATE_DEFENSE)
-	e3:SetValue(c100419003.defval)
+	e3:SetValue(c100407003.defval)
 	c:RegisterEffect(e3)
 	--disable
 	local e4=Effect.CreateEffect(c)
@@ -36,7 +36,7 @@ function c100419003.initial_effect(c)
 	e4:SetCode(EFFECT_DISABLE)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e4:SetTarget(c100419003.distg)
+	e4:SetTarget(c100407003.distg)
 	c:RegisterEffect(e4)
 	--atk limit
 	local e5=Effect.CreateEffect(c)
@@ -44,78 +44,78 @@ function c100419003.initial_effect(c)
 	e5:SetCode(EFFECT_CANNOT_ATTACK)
 	e5:SetRange(LOCATION_MZONE)
 	e5:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e5:SetTarget(c100419003.distg)
+	e5:SetTarget(c100407003.distg)
 	c:RegisterEffect(e5)
 end
-function c100419003.CanEquipMonster(c)
+function c100407003.CanEquipMonster(c)
 	return true
 end
-function c100419003.eqcon(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407003.eqcon(e,tp,eg,ep,ev,re,r,rp,chk)
 	return ep~=tp and re:IsActiveType(TYPE_MONSTER)
 end
-function c100419003.eqfilter(c)
+function c100407003.eqfilter(c)
 	return (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE)) and c:IsType(TYPE_EFFECT) and c:IsAbleToChangeControler()
 end
-function c100419003.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and chkc:IsControler(1-tp) and c100419003.eqfilter(chkc) end
+function c100407003.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and chkc:IsControler(1-tp) and c100407003.eqfilter(chkc) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c100419003.eqfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,nil) end
+		and Duel.IsExistingTarget(c100407003.eqfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c100419003.eqfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c100407003.eqfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
 end
-function c100419003.eqlimit(e,c)
+function c100407003.eqlimit(e,c)
 	return e:GetOwner()==c
 end
-function c100419003.EquipMonster(c,tp,tc)
+function c100407003.EquipMonster(c,tp,tc)
 	if not Duel.Equip(tp,tc,c,false) then return end
 	--Add Equip limit
-	tc:RegisterFlagEffect(100419003,RESET_EVENT+0x1fe0000,0,0)
+	tc:RegisterFlagEffect(100407003,RESET_EVENT+0x1fe0000,0,0)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	e1:SetValue(c100419003.eqlimit)
+	e1:SetValue(c100407003.eqlimit)
 	tc:RegisterEffect(e1)
 end
-function c100419003.eqop(e,tp,eg,ep,ev,re,r,rp)
+function c100407003.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) and tc:IsControler(1-tp) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
-			c100419003.EquipMonster(c,tp,tc)
+			c100407003.EquipMonster(c,tp,tc)
 		else Duel.SendtoGrave(tc,REASON_EFFECT) end
 	end
 end
-function c100419003.atkval(e,c)
+function c100407003.atkval(e,c)
 	local atk=0
 	local g=c:GetEquipGroup()
 	local tc=g:GetFirst()
 	while tc do
-		if tc:GetFlagEffect(100419003)~=0 and tc:IsFaceup() and tc:GetAttack()>=0 then
+		if tc:GetFlagEffect(100407003)~=0 and tc:IsFaceup() and tc:GetAttack()>=0 then
 			atk=atk+tc:GetAttack()
 		end
 		tc=g:GetNext()
 	end
 	return atk
 end
-function c100419003.defval(e,c)
+function c100407003.defval(e,c)
 	local atk=0
 	local g=c:GetEquipGroup()
 	local tc=g:GetFirst()
 	while tc do
-		if tc:GetFlagEffect(100419003)~=0 and tc:IsFaceup() and tc:GetDefense()>=0 then
+		if tc:GetFlagEffect(100407003)~=0 and tc:IsFaceup() and tc:GetDefense()>=0 then
 			atk=atk+tc:GetDefense()
 		end
 		tc=g:GetNext()
 	end
 	return atk
 end
-function c100419003.disfilter(c)
-	return c:IsFaceup() and c:GetFlagEffect(100419003)~=0
+function c100407003.disfilter(c)
+	return c:IsFaceup() and c:GetFlagEffect(100407003)~=0
 end
-function c100419003.distg(e,c)
-	local g=e:GetHandler():GetEquipGroup():Filter(c100419003.disfilter,nil)
+function c100407003.distg(e,c)
+	local g=e:GetHandler():GetEquipGroup():Filter(c100407003.disfilter,nil)
 	return c:IsFaceup() and g:IsExists(Card.IsCode,1,nil,c:GetCode())
 end

--- a/scripts/DP19-JP/c100407004.lua
+++ b/scripts/DP19-JP/c100407004.lua
@@ -1,65 +1,65 @@
 --サクリファイス・フュージョン
 --Relinquished Fusion
-function c100419004.initial_effect(c)
+function c100407004.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(c100419004.target)
-	e1:SetOperation(c100419004.activate)
+	e1:SetTarget(c100407004.target)
+	e1:SetOperation(c100407004.activate)
 	c:RegisterEffect(e1)
 	--equip
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(100419004,0))
+	e2:SetDescription(aux.Stringid(100407004,0))
 	e2:SetCategory(CATEGORY_EQUIP)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_GRAVE)
-	e2:SetCost(c100419004.eqcost)
-	e2:SetTarget(c100419004.eqtg)
-	e2:SetOperation(c100419004.eqop)
+	e2:SetCost(c100407004.eqcost)
+	e2:SetTarget(c100407004.eqtg)
+	e2:SetOperation(c100407004.eqop)
 	c:RegisterEffect(e2)
 end
-function c100419004.filter0(c)
+function c100407004.filter0(c)
 	return c:IsAbleToRemove()
 end
-function c100419004.filter1(c,e)
+function c100407004.filter1(c,e)
 	return c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
-function c100419004.filter2(c,e,tp,m,f,chkf)
+function c100407004.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
-function c100419004.filter3(c)
+function c100407004.filter3(c)
 	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x20a) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
 end
-function c100419004.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407004.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
-		local mg1=Duel.GetFusionMaterial(tp):Filter(c100419004.filter0,nil)
-		local mg2=Duel.GetMatchingGroup(c100419004.filter3,tp,LOCATION_MZONE+LOCATION_HAND+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c100407004.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c100407004.filter3,tp,LOCATION_MZONE+LOCATION_HAND+LOCATION_GRAVE,0,nil)
 		mg1:Merge(mg2)
-		local res=Duel.IsExistingMatchingCard(c100419004.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		local res=Duel.IsExistingMatchingCard(c100407004.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c100419004.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c100407004.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
-function c100419004.activate(e,tp,eg,ep,ev,re,r,rp)
+function c100407004.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=tp
-	local mg1=Duel.GetFusionMaterial(tp):Filter(c100419004.filter1,nil,e)
-	local mg2=Duel.GetMatchingGroup(c100419004.filter3,tp,LOCATION_MZONE+LOCATION_HAND+LOCATION_GRAVE,0,nil)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c100407004.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c100407004.filter3,tp,LOCATION_MZONE+LOCATION_HAND+LOCATION_GRAVE,0,nil)
 	mg1:Merge(mg2)
-	local sg1=Duel.GetMatchingGroup(c100419004.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local sg1=Duel.GetMatchingGroup(c100407004.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -67,7 +67,7 @@ function c100419004.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c100419004.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c100407004.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -89,30 +89,30 @@ function c100419004.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:CompleteProcedure()
 	end
 end
-function c100419004.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407004.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
-function c100419004.filter(c)
+function c100407004.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c:IsAbleToChangeControler()
 end
-function c100419004.eqfilter(c)
+function c100407004.eqfilter(c)
 	local m=_G["c"..c:GetCode()]
 	return c:IsFaceup() and (c:IsSetCard(0x20a) or c:IsCode(64631466)) and m.CanEquipMonster(c)
 end
-function c100419004.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c100419004.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c100419004.filter,tp,0,LOCATION_MZONE,1,nil)
-		and Duel.IsExistingMatchingCard(c100419004.eqfilter,tp,LOCATION_MZONE,0,1,nil) end
+function c100407004.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c100407004.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c100407004.filter,tp,0,LOCATION_MZONE,1,nil)
+		and Duel.IsExistingMatchingCard(c100407004.eqfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c100419004.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c100407004.filter,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
 end
-function c100419004.eqop(e,tp,eg,ep,ev,re,r,rp)
+function c100407004.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc1=Duel.GetFirstTarget()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectMatchingCard(tp,c100419004.eqfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c100407004.eqfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	local tc2=g:GetFirst()
 	local m=_G["c"..tc2:GetCode()]
 	if tc1:IsFaceup() and tc1:IsRelateToEffect(e) and tc1:IsControler(1-tp) and tc2 then

--- a/scripts/DP19-JP/c100407007.lua
+++ b/scripts/DP19-JP/c100407007.lua
@@ -1,7 +1,7 @@
 --寄生虫パラノイド
 --Parasite Paranoid
 --Scripted by Eerie Code
-function c100419007.initial_effect(c)
+function c100407007.initial_effect(c)
 	--equip
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
@@ -9,30 +9,30 @@ function c100419007.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetRange(LOCATION_HAND)
-	e1:SetCountLimit(1,100419007)
-	e1:SetTarget(c100419007.eqtg)
-	e1:SetOperation(c100419007.eqop)
+	e1:SetCountLimit(1,100407007)
+	e1:SetTarget(c100407007.eqtg)
+	e1:SetOperation(c100407007.eqop)
 	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(100419007,1))
+	e2:SetDescription(aux.Stringid(100407007,1))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_TO_GRAVE)
-	e2:SetCondition(c100419007.spcon)
-	e2:SetTarget(c100419007.sptg)
-	e2:SetOperation(c100419007.spop)
+	e2:SetCondition(c100407007.spcon)
+	e2:SetTarget(c100407007.sptg)
+	e2:SetOperation(c100407007.spop)
 	c:RegisterEffect(e2)
 end
-function c100419007.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function c100407007.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
-function c100419007.eqop(e,tp,eg,ep,ev,re,r,rp)
+function c100407007.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	if c:IsLocation(LOCATION_MZONE) and c:IsFacedown() then return end
@@ -46,7 +46,7 @@ function c100419007.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	e1:SetValue(c100419007.eqlimit)
+	e1:SetValue(c100407007.eqlimit)
 	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--race
@@ -60,7 +60,7 @@ function c100419007.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
 	e3:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
-	e3:SetValue(c100419007.atlimit)
+	e3:SetValue(c100407007.atlimit)
 	e3:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e3)
 	--disable
@@ -69,46 +69,46 @@ function c100419007.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e4:SetCode(EVENT_CHAIN_SOLVING)
 	e4:SetRange(LOCATION_SZONE)
 	e4:SetLabelObject(tc)
-	e4:SetCondition(c100419007.discon)
-	e4:SetOperation(c100419007.disop)
+	e4:SetCondition(c100407007.discon)
+	e4:SetOperation(c100407007.disop)
 	e4:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e4)
 end
-function c100419007.eqlimit(e,c)
+function c100407007.eqlimit(e,c)
 	return c==e:GetLabelObject()
 end
-function c100419007.atlimit(e,c)
+function c100407007.atlimit(e,c)
 	return c:IsRace(RACE_INSECT)
 end
-function c100419007.disfilter(c)
+function c100407007.disfilter(c)
 	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_INSECT)
 end
-function c100419007.discon(e,tp,eg,ep,ev,re,r,rp)
+function c100407007.discon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
 	local rc=re:GetHandler()
 	if not tc or rc~=tc then return false end
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	return g and g:IsExists(c100419007.disfilter,1,nil) and Duel.IsChainNegatable(ev)
+	return g and g:IsExists(c100407007.disfilter,1,nil) and Duel.IsChainNegatable(ev)
 end
-function c100419007.disop(e,tp,eg,ep,ev,re,r,rp)
+function c100407007.disop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateEffect(ev)
 end
-function c100419007.spcon(e,tp,eg,ep,ev,re,r,rp)
+function c100407007.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_SZONE)
 end
-function c100419007.spfilter(c,e,tp)
+function c100407007.spfilter(c,e,tp)
 	return c:IsRace(RACE_INSECT) and c:IsLevelAbove(7) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
-function c100419007.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407007.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c100419007.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c100407007.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
-function c100419007.spop(e,tp,eg,ep,ev,re,r,rp)
+function c100407007.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c100419007.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	local g=Duel.SelectMatchingCard(tp,c100407007.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)
 	end

--- a/scripts/DP19-JP/c100407008.lua
+++ b/scripts/DP19-JP/c100407008.lua
@@ -1,14 +1,14 @@
 --究極変異態・インセクト女王
 --Ultimately Mutated Insect Queen
 --Scripted by Eerie Code
-function c100419008.initial_effect(c)
+function c100407008.initial_effect(c)
 	c:EnableUnsummonable()
 	--cannot special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(c100419008.splimit)
+	e1:SetValue(c100407008.splimit)
 	c:RegisterEffect(e1)
 	--indes
 	local e2=Effect.CreateEffect(c)
@@ -16,9 +16,9 @@ function c100419008.initial_effect(c)
 	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetTargetRange(LOCATION_MZONE,0)
-	e2:SetCondition(c100419008.indcon)
+	e2:SetCondition(c100407008.indcon)
 	e2:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_INSECT))
-	e2:SetValue(c100419008.indval)
+	e2:SetValue(c100407008.indval)
 	c:RegisterEffect(e2)
 	--cannot be target
 	local e3=Effect.CreateEffect(c)
@@ -27,18 +27,18 @@ function c100419008.initial_effect(c)
 	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 	e3:SetRange(LOCATION_SZONE)
 	e3:SetTargetRange(LOCATION_MZONE,0)
-	e3:SetCondition(c100419008.indcon)
+	e3:SetCondition(c100407008.indcon)
 	e3:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_INSECT))
 	e3:SetValue(aux.tgoval)
 	c:RegisterEffect(e3)
 	--chain attack
 	local e4=Effect.CreateEffect(c)
-	e4:SetDescription(aux.Stringid(100419008,0))
+	e4:SetDescription(aux.Stringid(100407008,0))
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e4:SetCode(EVENT_DAMAGE_STEP_END)
-	e4:SetCondition(c100419008.atcon)
-	e4:SetCost(c100419008.atcost)
-	e4:SetOperation(c100419008.atop)
+	e4:SetCondition(c100407008.atcon)
+	e4:SetCost(c100407008.atcost)
+	e4:SetOperation(c100407008.atop)
 	c:RegisterEffect(e4)
 	--spsummon
 	local e5=Effect.CreateEffect(c)
@@ -48,32 +48,32 @@ function c100419008.initial_effect(c)
 	e5:SetRange(LOCATION_MZONE)
 	e5:SetCode(EVENT_PHASE+PHASE_END)
 	e5:SetCountLimit(1)
-	e5:SetTarget(c100419008.sptg)
-	e5:SetOperation(c100419008.spop)
+	e5:SetTarget(c100407008.sptg)
+	e5:SetOperation(c100407008.spop)
 	c:RegisterEffect(e4)
 end
-function c100419008.splimit(e,se,sp,st)
+function c100407008.splimit(e,se,sp,st)
 	return se:IsHasType(EFFECT_TYPE_ACTIONS)
 end
-function c100419008.indfilter(c)
+function c100407008.indfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_INSECT)
 end
-function c100419008.indcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c100419008.indfilter,tp,LOCATION_MZONE,0,1,e:GetHandler())
+function c100407008.indcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c100407008.indfilter,tp,LOCATION_MZONE,0,1,e:GetHandler())
 end
-function c100419008.indval(e,re,rp)
+function c100407008.indval(e,re,rp)
 	return rp~=e:GetHandlerPlayer()
 end
-function c100419008.atcon(e,tp,eg,ep,ev,re,r,rp)
+function c100407008.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return Duel.GetAttacker()==c and c:IsChainAttackable(0,true)
 end
-function c100419008.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407008.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,nil,1,e:GetHandler()) nd
 	local g=Duel.SelectReleaseGroup(tp,nil,1,1,e:GetHandler())
 	Duel.Release(g,REASON_COST)
 end
-function c100419008.atop(e,tp,eg,ep,ev,re,r,rp)
+function c100407008.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToBattle() then return end
 	Duel.ChainAttack()
@@ -84,13 +84,13 @@ function c100419008.atop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE+PHASE_DAMAGE_CAL)
 	c:RegisterEffect(e1)
 end
-function c100419008.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407008.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,91512836,0,0x4011,100,100,1,RACE_INSECT,ATTRIBUTE_EARTH) end
 	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
 end
-function c100419008.spop(e,tp,eg,ep,ev,re,r,rp)
+function c100407008.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if not Duel.IsPlayerCanSpecialSummonMonster(tp,91512836,0,0x4011,100,100,1,RACE_INSECT,ATTRIBUTE_EARTH) then return end
 	local token=Duel.CreateToken(tp,91512836)

--- a/scripts/DP19-JP/c100407009.lua
+++ b/scripts/DP19-JP/c100407009.lua
@@ -1,70 +1,70 @@
 --超進化の繭
 --Super Cocoon of Evolution
 --Scripted by Eerie Code
-function c100419009.initial_effect(c)
+function c100407009.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(c100419009.target)
-	e1:SetOperation(c100419009.activate)
+	e1:SetTarget(c100407009.target)
+	e1:SetOperation(c100407009.activate)
 	c:RegisterEffect(e1)
 	--shuffle and draw
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetCountLimit(1,100419009)
+	e2:SetCountLimit(1,100407009)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCost(aux.bfgcost)
-	e2:SetTarget(c100419009.tdtg)
-	e2:SetOperation(c100419009.tdop)
+	e2:SetTarget(c100407009.tdtg)
+	e2:SetOperation(c100407009.tdop)
 	c:RegisterEffect(e2)
 end
-function c100419009.cfilter(c)
+function c100407009.cfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_INSECT) and c:IsReleasableByEffect()
 		and c:GetEquipCount()>0
 end
-function c100419009.filter(c,e,tp)
+function c100407009.filter(c,e,tp)
 	return c:IsRace(RACE_INSECT) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
-function c100419009.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407009.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local loc=LOCATION_MZONE
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then loc=0 end
-		return Duel.IsExistingMatchingCard(c100419009.cfilter,tp,LOCATION_MZONE,loc,1,nil)
-			and Duel.IsExistingMatchingCard(c100419009.filter,tp,LOCATION_DECK,0,1,nil,e,tp)
+		return Duel.IsExistingMatchingCard(c100407009.cfilter,tp,LOCATION_MZONE,loc,1,nil)
+			and Duel.IsExistingMatchingCard(c100407009.filter,tp,LOCATION_DECK,0,1,nil,e,tp)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_RELEASE,nil,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
-function c100419009.activate(e,tp,eg,ep,ev,re,r,rp)
+function c100407009.activate(e,tp,eg,ep,ev,re,r,rp)
 	local loc=LOCATION_MZONE
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then loc=0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-	local g=Duel.SelectMatchingCard(tp,c100419009.cfilter,tp,LOCATION_MZONE,loc,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c100407009.cfilter,tp,LOCATION_MZONE,loc,1,1,nil)
 	if g:GetCount()>0 and Duel.Release(g,REASON_EFFECT)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sg=Duel.SelectMatchingCard(tp,c100419009.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		local sg=Duel.SelectMatchingCard(tp,c100407009.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 		if sg:GetCount()>0 then
 			Duel.SpecialSummon(sg,0,tp,tp,true,false,POS_FACEUP)
 		end
 	end
 end
-function c100419009.tdfilter(c)
+function c100407009.tdfilter(c)
 	return c:IsRace(RACE_INSECT) and c:IsAbleToDeck()
 end
-function c100419009.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c100419009.tdfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c100419009.tdfilter,tp,LOCATION_GRAVE,0,1,nil)
+function c100407009.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c100407009.tdfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c100407009.tdfilter,tp,LOCATION_GRAVE,0,1,nil)
 		and Duel.IsPlayerCanDraw(tp,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local g=Duel.SelectTarget(tp,c100419009.tdfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectTarget(tp,c100407009.tdfilter,tp,LOCATION_GRAVE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end
-function c100419009.tdop(e,tp,eg,ep,ev,re,r,rp)
+function c100407009.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0
 		and tc:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then

--- a/scripts/DP19-JP/c100407014.lua
+++ b/scripts/DP19-JP/c100407014.lua
@@ -1,80 +1,80 @@
 --BM-4 ボムスパイダー
 --BM-4 Bomb Spider
 --Scripted by Eerie Code
-function c100419014.initial_effect(c)
+function c100407014.initial_effect(c)
 	--Destroy
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(100419014,0))
+	e1:SetDescription(aux.Stringid(100407014,0))
 	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_IGNITION)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
-	e1:SetTarget(c100419014.destg)
-	e1:SetOperation(c100419014.desop)
+	e1:SetTarget(c100407014.destg)
+	e1:SetOperation(c100407014.desop)
 	c:RegisterEffect(e1)
 	--damage
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(100419014,0))
+	e2:SetDescription(aux.Stringid(100407014,0))
 	e2:SetCategory(CATEGORY_DAMAGE)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_BATTLE_DESTROYED)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCountLimit(1,100419014)
-	e2:SetCondition(c100419014.damcon1)
-	e2:SetTarget(c100419014.damtg)
-	e2:SetOperation(c100419014.damop)
+	e2:SetCountLimit(1,100407014)
+	e2:SetCondition(c100407014.damcon1)
+	e2:SetTarget(c100407014.damtg)
+	e2:SetOperation(c100407014.damop)
 	c:RegisterEffect(e2)
 	local e3=e2:Clone()
 	e3:SetCode(EVENT_TO_GRAVE)
-	e3:SetCondition(c100419014.damcon2)
+	e3:SetCondition(c100407014.damcon2)
 	c:RegisterEffect(e3)
 end
-function c100419014.desfilter(c)
+function c100407014.desfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK)
 end
-function c100419014.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function c100407014.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return Duel.IsExistingTarget(c100419014.desfilter,tp,LOCATION_MZONE,0,1,nil)
+	if chk==0 then return Duel.IsExistingTarget(c100407014.desfilter,tp,LOCATION_MZONE,0,1,nil)
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_ONFIELD,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g1=Duel.SelectTarget(tp,c100419014.desfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	local g1=Duel.SelectTarget(tp,c100407014.desfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g2=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_ONFIELD,1,1,nil)
 	g1:Merge(g2)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g1,2,0,0)
 end
-function c100419014.desop(e,tp,eg,ep,ev,re,r,rp)
+function c100407014.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tg=g:Filter(Card.IsRelateToEffect,nil,e)
 	if tg:GetCount()>0 then
 		Duel.Destroy(tg,REASON_EFFECT)
 	end
 end
-function c100419014.damcon1(e,tp,eg,ep,ev,re,r,rp)
+function c100407014.damcon1(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	local bc=tc:GetBattleTarget()
 	return tc:GetPreviousControler()~=tp and tc:IsLocation(LOCATION_GRAVE)
 		and bc:IsControler(tp) and bc:GetOriginalAttribute()==ATTRIBUTE_DARK and bc:GetOriginalRace()==RACE_MACHINE
 end
-function c100419014.damfilter1(c,tp)
+function c100407014.damfilter1(c,tp)
 	return c:IsReason(REASON_EFFECT) and c:IsReason(REASON_DESTROY) and c:IsLocation(LOCATION_GRAVE) and c:GetPreviousControler()~=tp
 end
-function c100419014.damcon2(e,tp,eg,ep,ev,re,r,rp)
+function c100407014.damcon2(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	return rc:IsControler(tp) and rc:GetOriginalAttribute()==ATTRIBUTE_DARK
 		and rc:GetOriginalRace()==RACE_MACHINE
-		and eg:IsExists(c100419014.damfilter1,1,nil,tp)
+		and eg:IsExists(c100407014.damfilter1,1,nil,tp)
 end
-function c100419014.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407014.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
 end
-function c100419014.damfilter2(c,tp)
+function c100407014.damfilter2(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsReason(REASON_DESTROY) and c:IsLocation(LOCATION_GRAVE) and c:GetPreviousControler()~=tp
 end
-function c100419014.damop(e,tp,eg,ep,ev,re,r,rp)
-	local g=eg:Filter(c100419014.damfilter2,nil,tp)
+function c100407014.damop(e,tp,eg,ep,ev,re,r,rp)
+	local g=eg:Filter(c100407014.damfilter2,nil,tp)
 	if g:GetCount()>0 then
 		if g:GetCount()>1 then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)

--- a/scripts/DP19-JP/c100407015.lua
+++ b/scripts/DP19-JP/c100407015.lua
@@ -1,58 +1,58 @@
 -- デスペラード・リボルバー・ドラゴン
 --Desperado Barrel Dragon
-function c100419015.initial_effect(c)
+function c100407015.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(100419015,0))
+	e1:SetDescription(aux.Stringid(100407015,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCode(EVENT_DESTROYED)
-	e1:SetCondition(c100419015.condition)
-	e1:SetTarget(c100419015.target)
-	e1:SetOperation(c100419015.operation)
+	e1:SetCondition(c100407015.condition)
+	e1:SetTarget(c100407015.target)
+	e1:SetOperation(c100407015.operation)
 	c:RegisterEffect(e1)
 	--destroy
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(100419015,1))
+	e2:SetDescription(aux.Stringid(100407015,1))
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_COIN+CATEGORY_DRAW)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)
-	e2:SetCondition(c100419015.descon)
+	e2:SetCondition(c100407015.descon)
 	e2:SetCost(c68450517.descost)
-	e2:SetTarget(c100419015.destg)
-	e2:SetOperation(c100419015.desop)
+	e2:SetTarget(c100407015.destg)
+	e2:SetOperation(c100407015.desop)
 	c:RegisterEffect(e2)
 	--search
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(100419015,2))
+	e3:SetDescription(aux.Stringid(100407015,2))
 	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetCode(EVENT_TO_GRAVE)
-	e3:SetTarget(c100419015.thtg)
-	e3:SetOperation(c100419015.thop)
+	e3:SetTarget(c100407015.thtg)
+	e3:SetOperation(c100407015.thop)
 	c:RegisterEffect(e3)
 end
-c100419015.toss_coin=true
-function c100419015.filter(c,tp)
+c100407015.toss_coin=true
+function c100407015.filter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and bit.band(c:GetPreviousRaceOnField(),RACE_MACHINE)~=0
 		and bit.band(c:GetPreviousAttributeOnField(),ATTRIBUTE_DARK)~=0 and c:GetPreviousControler()==tp
 		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
 end
-function c100419015.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c100419015.filter,1,nil,tp)
+function c100407015.condition(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c100407015.filter,1,nil,tp)
 end
-function c100419015.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407015.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
-function c100419015.operation(e,tp,eg,ep,ev,re,r,rp)
+function c100407015.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
@@ -69,12 +69,12 @@ function c68450517.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 	e:GetHandler():RegisterEffect(e1)
 end
-function c100419015.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c100407015.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,3)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end
-function c100419015.desop(e,tp,eg,ep,ev,re,r,rp)
+function c100407015.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if g:GetCount()==0 then return end
 	local c1,c2,c3=Duel.TossCoin(tp,3)
@@ -89,16 +89,16 @@ function c100419015.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 end
-function c100419015.thfilter(c)
+function c100407015.thfilter(c)
 	return c.toss_coin and c:IsType(TYPE_MONSTER) and c:IsLevelBelow(7) and c:IsAbleToHand()
 end
-function c100419015.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c100419015.thfilter,tp,LOCATION_DECK,0,1,nil) end
+function c100407015.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c100407015.thfilter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
-function c100419015.thop(e,tp,eg,ep,ev,re,r,rp)
+function c100407015.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c100419015.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c100407015.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/scripts/DP19-JP/c100407017.lua
+++ b/scripts/DP19-JP/c100407017.lua
@@ -1,7 +1,7 @@
 --銃砲撃
 --Gun Cannon Shot
 --Script by nekrozar
-function c100419017.initial_effect(c)
+function c100407017.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -13,42 +13,42 @@ function c100419017.initial_effect(c)
 	e2:SetCode(EVENT_CHAINING)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1)
-	e2:SetCondition(c100419017.regcon)
-	e2:SetOperation(c100419017.regop)
+	e2:SetCondition(c100407017.regcon)
+	e2:SetOperation(c100407017.regop)
 	c:RegisterEffect(e2)
 	--coin result
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(100419017,0))
+	e3:SetDescription(aux.Stringid(100407017,0))
 	e3:SetType(EFFECT_TYPE_QUICK_O)
 	e3:SetCode(EVENT_CHAINING)
 	e3:SetRange(LOCATION_GRAVE)
-	e3:SetCondition(c100419017.coincon1)
+	e3:SetCondition(c100407017.coincon1)
 	e3:SetCost(aux.bfgcost)
-	e3:SetOperation(c100419017.coinop1)
+	e3:SetOperation(c100407017.coinop1)
 	c:RegisterEffect(e3)
 end
-function c100419017.regcon(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.regcon(e,tp,eg,ep,ev,re,r,rp)
 	local ex=Duel.GetOperationInfo(ev,CATEGORY_COIN)
 	return ex
 end
-function c100419017.regop(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetProperty(EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_TOSS_COIN)
 	e1:SetRange(LOCATION_SZONE)
-	e1:SetCondition(c100419017.effcon)
-	e1:SetOperation(c100419017.effop)
+	e1:SetCondition(c100407017.effcon)
+	e1:SetOperation(c100407017.effop)
 	e1:SetLabelObject(re)
 	e1:SetReset(RESET_EVENT+0x1fc0000+RESET_CHAIN)
 	c:RegisterEffect(e1)
 end
-function c100419017.effcon(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.effcon(e,tp,eg,ep,ev,re,r,rp)
 	return re==e:GetLabelObject()
 end
-function c100419017.effop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_CARD,0,100419017)
+function c100407017.effop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,100407017)
 	local ct=0
 	local res={Duel.GetCoinResult()}
 	for i=1,ev do
@@ -78,28 +78,28 @@ function c100419017.effop(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 end
-function c100419017.coincon1(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.coincon1(e,tp,eg,ep,ev,re,r,rp)
 	local ex,eg,et,cp,ct=Duel.GetOperationInfo(ev,CATEGORY_COIN)
 	if ex and ct>1 then
 		e:SetLabelObject(re)
 		return true
 	else return false end
 end
-function c100419017.coinop1(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.coinop1(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_TOSS_COIN_NEGATE)
 	e1:SetCountLimit(1)
-	e1:SetCondition(c100419017.coincon2)
-	e1:SetOperation(c100419017.coinop2)
+	e1:SetCondition(c100407017.coincon2)
+	e1:SetOperation(c100407017.coinop2)
 	e1:SetLabelObject(e:GetLabelObject())
 	e1:SetReset(RESET_CHAIN)
 	Duel.RegisterEffect(e1,tp)
 end
-function c100419017.coincon2(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.coincon2(e,tp,eg,ep,ev,re,r,rp)
 	return re==e:GetLabelObject()
 end
-function c100419017.coinop2(e,tp,eg,ep,ev,re,r,rp)
+function c100407017.coinop2(e,tp,eg,ep,ev,re,r,rp)
 	local res={Duel.GetCoinResult()}
 	local ct=ev
 	for i=1,ct do


### PR DESCRIPTION
The real issue for DP19 is the fact that we've been using the wrong series of number for DBSW in the first place, 100419XXX where it should have been 100407XXX. As such, I propose giving that missing range to DP19 instead: this way, it'd be like we had used the correct ranges from the beginning, and there won't be issues with future sets' numerations.

Now, I realize you might have some objections to this, like how this new range would violate the system we've estabilished so far, or that changing cards now that they're on server might be an inconvenience for players: I fully understand, and I'm sorry a situation like this happened in the first place. However, here are my counterpoints:
 - The system of ranges has already been violated at this point: DBSW's range doesn't follow it either, and it's already too late to remedy that. By using this new range on DP19, though, we can at least avoid future problems in the next sets.
 - While changing the cards already on server would definitely be an inconvenience, I'd argue that not doing anything would be an even greater inconvenience for the players. For better or for worse, all Ygopro simulators use FH's system for the new cards: leaving things as we are, who knows what kind of problems could end up on their side? @StormWulf already nailed one of the major ones: players who rely on automatic Deck converters won't be able to use them properly anymore, because those would end up affected by a basically unfixable bug (how can the converter know if they're trying to convert from DBSW or from DP19?)

So, this is my proposal for a solution. Please, consider approving this: we're talking about a minor inconvenience making an update that the new cards have been out for barely 2 days, fixing the problem definitely, or leaving things as they are and leaving issues in all simulators for the next two months at minimum. Which is the better choice?