### PR TITLE
Fix 永の王 オルムガンド

### DIFF
--- a/scripts/DBMF-JP/c100413033.lua
+++ b/scripts/DBMF-JP/c100413033.lua
@@ -43,7 +43,7 @@ function c100413033.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,PLAYER_ALL,1)
 end
 function c100413033.ofilter(c,tp)
-	return not c:IsType(TYPE_TOKEN) and (c:IsControler(tp) or c:IsAbleToChangeControler()) and not c:IsStatus(STATUS_LEAVE_CONFIRMED)
+	return not c:IsType(TYPE_TOKEN) and (c:IsControler(tp) or c:IsAbleToChangeControler())
 end
 function c100413033.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -57,14 +57,20 @@ function c100413033.drop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.ShuffleHand(tp)
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 			local tc1=tg1:Select(tp,1,1,nil):GetFirst()
-			sg:AddCard(tc1)
+			if tc1 and not tc1:IsImmuneToEffect(e) then
+				tc1:CancelToGrave()
+				sg:AddCard(tc1)
+			end
 		end
 		local tg2=Duel.GetMatchingGroup(c100413033.ofilter,1-tp,LOCATION_HAND+LOCATION_ONFIELD,0,aux.ExceptThisCard(e),cp)
 		if ed>0 and tg2:GetCount()>0 then
 			Duel.ShuffleHand(1-tp)
 			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_XMATERIAL)
 			local tc2=tg2:Select(1-tp,1,1,nil):GetFirst()
-			sg:AddCard(tc2)
+			if tc2 and not tc2:IsImmuneToEffect(e) then
+				tc2:CancelToGrave()
+				sg:AddCard(tc2)
+			end
 		end
 		if sg:GetCount()>0 then
 			Duel.BreakEffect()


### PR DESCRIPTION
> Q. 
「サイクロン」の発動にチェーンして「永の王 オルムガンド」の③効果を発動し、「永の王 オルムガンド」の③効果によってエクシーズ素材とするカードを選ぶ際に、チェーン1の「サイクロン」を選べますか？ 
Q：「永の王 オルムガンド」の③効果の発動にチェーンして「サイクロン」を発動し、「永の王 オルムガンド」の③効果によってエクシーズ素材とするカードを選ぶ際に、チェーン2の「サイクロン」を選べますか？ 
A. 
どちらのご質問の場合でも、発動して表側表示で存在している「サイクロン」を「永の王 オルムガンド」のエクシーズ素材にすることもできます。

> Q. 
「永の王 オルムガンド」の③効果によってエクシーズ素材とするカードを選ぶ際に、カードの効果を受けない「RR－アルティメット・ファルコン」や、モンスターが発動した効果を受けない「アポクリフォート・キラー」を選べますか？ 
（「永の王 オルムガンド」の③効果はモンスターに適用される効果ではなく、プレイヤーに適用される効果ですか？） 
A. 
「永の王 オルムガンド」の『③』の効果でエクシーズ素材とするカードとして、モンスターゾーンの「RR－アルティメット・ファルコン」や「アポクリフォート・キラー」を選ぶことはできます。 
ただし、その「RR－アルティメット・ファルコン」や「アポクリフォート・キラー」は効果を受けませんので、結果的にもう片方のプレイヤーのみが、選んだカードをエクシーズ素材とすることになります。