### PR TITLE
add メガリス

### DIFF
--- a/scripts/IGAS-JP/c101011035.lua
+++ b/scripts/IGAS-JP/c101011035.lua
@@ -1,0 +1,86 @@
+--メガリス・オフィエル
+
+--Scripted by mallu11
+function c101011035.initial_effect(c)
+	c:EnableReviveLimit()
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011035,0))
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCondition(c101011035.srcon)
+	e1:SetTarget(c101011035.srtg)
+	e1:SetOperation(c101011035.srop)
+	c:RegisterEffect(e1)
+	--ritual summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011035,1))
+	e2:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,101011035)
+	e2:SetTarget(c101011035.rstg)
+	e2:SetOperation(c101011035.rsop)
+	c:RegisterEffect(e2)
+end
+function c101011035.srfilter(c)
+	return c:IsSetCard(0x238) and c:IsType(TYPE_MONSTER) and not c:IsCode(101011035) and c:IsAbleToHand()
+end
+function c101011035.srcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL)
+end
+function c101011035.srtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c101011035.srfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c101011035.srop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c101011035.srfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c101011035.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		local sg=nil
+		return mg:IsContains(c) and Duel.IsExistingMatchingCard(aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011035.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	if c:GetControler()~=tp or not c:IsRelateToEffect(e) or not mg:IsContains(c) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+		mg:RemoveCard(tc)
+		end
+		if not mg:IsContains(c) then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		Duel.SetSelectedCard(c)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end

--- a/scripts/IGAS-JP/c101011036.lua
+++ b/scripts/IGAS-JP/c101011036.lua
@@ -1,0 +1,86 @@
+--メガリス・ハギト
+
+--Scripted by mallu11
+function c101011036.initial_effect(c)
+	c:EnableReviveLimit()
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011036,0))
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCondition(c101011036.srcon)
+	e1:SetTarget(c101011036.srtg)
+	e1:SetOperation(c101011036.srop)
+	c:RegisterEffect(e1)
+	--ritual summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011036,1))
+	e2:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,101011036)
+	e2:SetTarget(c101011036.rstg)
+	e2:SetOperation(c101011036.rsop)
+	c:RegisterEffect(e2)
+end
+function c101011036.srfilter(c)
+	return c:IsSetCard(0x238) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()
+end
+function c101011036.srcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL)
+end
+function c101011036.srtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c101011036.srfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c101011036.srop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c101011036.srfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c101011036.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		local sg=nil
+		return mg:IsContains(c) and Duel.IsExistingMatchingCard(aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011036.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	if c:GetControler()~=tp or not c:IsRelateToEffect(e) or not mg:IsContains(c) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+		mg:RemoveCard(tc)
+		end
+		if not mg:IsContains(c) then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		Duel.SetSelectedCard(c)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end

--- a/scripts/IGAS-JP/c101011037.lua
+++ b/scripts/IGAS-JP/c101011037.lua
@@ -1,0 +1,95 @@
+--メガリス・オク
+
+--Scripted by mallu11
+function c101011037.initial_effect(c)
+	c:EnableReviveLimit()
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011037,0))
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_HANDES)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCondition(c101011037.drcon)
+	e1:SetTarget(c101011037.drtg)
+	e1:SetOperation(c101011037.drop)
+	c:RegisterEffect(e1)
+	--ritual summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011037,1))
+	e2:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
+	e2:SetCountLimit(1,101011037)
+	e2:SetCondition(c101011037.rscon)
+	e2:SetTarget(c101011037.rstg)
+	e2:SetOperation(c101011037.rsop)
+	c:RegisterEffect(e2)
+end
+function c101011037.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL)
+end
+function c101011037.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
+end
+function c101011037.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 then
+		Duel.BreakEffect()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+		local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,LOCATION_HAND,0,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.SendtoGrave(g,REASON_EFFECT+REASON_DISCARD)
+		end
+	end
+end
+function c101011037.rscon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
+end
+function c101011037.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		local sg=nil
+		return mg:IsContains(c) and Duel.IsExistingMatchingCard(aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011037.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	if c:GetControler()~=tp or not c:IsRelateToEffect(e) or not mg:IsContains(c) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter2,tp,LOCATION_HAND,0,1,1,nil,aux.TRUE,e,tp,mg,sg,Card.GetLevel,"Greater",c)
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+		mg:RemoveCard(tc)
+		end
+		if not mg:IsContains(c) then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		Duel.SetSelectedCard(c)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end

--- a/scripts/IGAS-JP/c101011038.lua
+++ b/scripts/IGAS-JP/c101011038.lua
@@ -1,0 +1,80 @@
+--メガリス・ファレグ
+
+--Scripted by mallu11
+function c101011038.initial_effect(c)
+	c:EnableReviveLimit()
+	--ritual summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011038,0))
+	e1:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,101011038)
+	e1:SetCost(c101011038.rscost)
+	e1:SetTarget(c101011038.rstg)
+	e1:SetOperation(c101011038.rsop)
+	c:RegisterEffect(e1)
+	--atk/def up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetValue(c101011038.val)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+end
+function c101011038.filter(c)
+	return c:IsSetCard(0x238)
+end
+function c101011038.rscost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c101011038.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		if mg:IsContains(c) then
+			mg:RemoveCard(c)
+		end
+		local sg=nil
+		return Duel.IsExistingMatchingCard(aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,c,c101011038.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011038.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,1,nil,c101011038.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+			mg:RemoveCard(tc)
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end
+function c101011038.val(e,c)
+	local g=Duel.GetFieldGroup(e:GetHandlerPlayer(),LOCATION_GRAVE,0)
+	local sg=g:Filter(Card.IsType,nil,TYPE_RITUAL)
+	return sg:GetCount()*300
+end

--- a/scripts/IGAS-JP/c101011039.lua
+++ b/scripts/IGAS-JP/c101011039.lua
@@ -1,0 +1,94 @@
+--メガリス・ベトール
+
+--Scripted by mallu11
+function c101011039.initial_effect(c)
+	c:EnableReviveLimit()
+	--ritual summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011039,0))
+	e1:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,101011039)
+	e1:SetCost(c101011039.rscost)
+	e1:SetTarget(c101011039.rstg)
+	e1:SetOperation(c101011039.rsop)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011039,1))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e2:SetCountLimit(1,101011139)
+	e2:SetCondition(c101011039.descon)
+	e2:SetTarget(c101011039.destg)
+	e2:SetOperation(c101011039.desop)
+	c:RegisterEffect(e2)
+end
+function c101011039.filter(c)
+	return c:IsSetCard(0x238)
+end
+function c101011039.rscost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c101011039.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		if mg:IsContains(c) then
+			mg:RemoveCard(c)
+		end
+		local sg=nil
+		return Duel.IsExistingMatchingCard(aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,c,c101011039.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011039.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,1,nil,c101011039.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+			mg:RemoveCard(tc)
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end
+function c101011039.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL)
+end
+function c101011039.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_ONFIELD) and chkc:IsControler(1-tp) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_RITUAL) and Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) end
+	local g=Duel.GetMatchingGroup(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_RITUAL)
+	local gc=g:GetClassCount(Card.GetCode)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local sg=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,gc,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
+end
+function c101011039.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if tg:GetCount()>0 then
+		Duel.Destroy(tg,REASON_EFFECT)
+	end
+end

--- a/scripts/IGAS-JP/c101011040.lua
+++ b/scripts/IGAS-JP/c101011040.lua
@@ -1,0 +1,113 @@
+--メガリス・アラトロン
+
+--Scripted by mallu11
+function c101011040.initial_effect(c)
+	c:EnableReviveLimit()
+	--ritual summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011040,0))
+	e1:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
+	e1:SetCountLimit(1,101011040)
+	e1:SetCondition(c101011040.rscon)
+	e1:SetCost(c101011040.rscost)
+	e1:SetTarget(c101011040.rstg)
+	e1:SetOperation(c101011040.rsop)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011040,1))
+	e2:SetCategory(CATEGORY_TODECK+CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,101011140)
+	e2:SetCondition(c101011040.discon)
+	e2:SetTarget(c101011040.distg)
+	e2:SetOperation(c101011040.disop)
+	c:RegisterEffect(e2)
+end
+function c101011040.filter(c)
+	return c:IsSetCard(0x238)
+end
+function c101011040.rscon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
+end
+function c101011040.rscost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c101011040.rstg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		if mg:IsContains(c) then
+			mg:RemoveCard(c)
+		end
+		local sg=nil
+		return Duel.IsExistingMatchingCard(aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,c,c101011040.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c101011040.rsop(e,tp,eg,ep,ev,re,r,rp)
+	local mg=Duel.GetRitualMaterial(tp)
+	local sg=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,aux.RitualUltimateFilter,tp,LOCATION_HAND,0,1,1,nil,c101011040.filter,e,tp,mg,sg,Card.GetLevel,"Greater")
+	local tc=tg:GetFirst()
+	if tc then
+		mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
+		if sg then
+			mg:Merge(sg)
+		end
+		if tc.mat_filter then
+			mg=mg:Filter(tc.mat_filter,tc,tp)
+		else
+			mg:RemoveCard(tc)
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		aux.GCheckAdditional=aux.RitualCheckAdditional(tc,tc:GetLevel(),"Greater")
+		local mat=mg:SelectSubGroup(tp,aux.RitualCheck,false,1,tc:GetLevel(),tp,tc,tc:GetLevel(),"Greater")
+		aux.GCheckAdditional=nil
+		if not mat or mat:GetCount()==0 then return end
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end
+function c101011040.tfilter(c,tp)
+	return c:IsOnField() and c:IsControler(tp)
+end
+function c101011040.disfilter(c)
+	return c:IsType(TYPE_RITUAL) and c:IsAbleToDeck()
+end
+function c101011040.discon(e,tp,eg,ep,ev,re,r,rp)
+	if rp==tp or e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return tg and tg:IsExists(c101011040.tfilter,1,nil,tp) and Duel.IsChainNegatable(ev)
+end
+function c101011040.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c101011040.disfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,nil,1,tp,LOCATION_GRAVE)
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c101011040.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectMatchingCard(tp,c101011040.disfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoDeck(g,nil,1,REASON_EFFECT)
+		if g:GetFirst():IsLocation(LOCATION_DECK) and Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(eg,REASON_EFFECT)
+		end
+	end
+end

--- a/scripts/IGAS-JP/c101011057.lua
+++ b/scripts/IGAS-JP/c101011057.lua
@@ -1,0 +1,63 @@
+--メガリス・ポータル
+
+--Scripted by mallu11
+function c101011057.initial_effect(c)
+	--activate
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_ACTIVATE)
+	e0:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e0)
+	--indes
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
+	e1:SetRange(LOCATION_FZONE)
+	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e1:SetTarget(c101011057.indtg)
+	e1:SetValue(c101011057.indct)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(101011057,0))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetCountLimit(1,101011057)
+	e2:SetCondition(c101011057.thcon)
+	e2:SetTarget(c101011057.thtg)
+	e2:SetOperation(c101011057.thop)
+	c:RegisterEffect(e2)
+end
+function c101011057.indtg(e,c)
+	return c:IsSummonType(SUMMON_TYPE_RITUAL)
+end
+function c101011057.indct(e,re,r,rp)
+	if bit.band(r,REASON_BATTLE)~=0 then
+		return 1
+	else return 0 end
+end
+function c101011057.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x238)
+end
+function c101011057.thfilter(c)
+	return c:IsType(TYPE_RITUAL) and c:IsAbleToHand()
+end
+function c101011057.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c101011057.cfilter,1,nil)
+end
+function c101011057.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c101011057.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c101011057.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c101011057.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c101011057.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/scripts/IGAS-JP/c101011071.lua
+++ b/scripts/IGAS-JP/c101011071.lua
@@ -1,0 +1,44 @@
+--メガリス・プロモーション
+
+--Scripted by mallu11
+function c101011071.initial_effect(c)
+	--activate
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_ACTIVATE)
+	e0:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e0)
+	--lv change
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011071,0))
+	e1:SetCategory(CATEGORY_LVCHANGE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetCountLimit(1,101011071)
+	e1:SetTarget(c101011071.lvtg)
+	e1:SetOperation(c101011071.lvop)
+	c:RegisterEffect(e1)
+end
+function c101011071.filter(c)
+	return c:IsFaceup() and c:IsLevelAbove(1) and c:IsLevelBelow(4)
+end
+function c101011071.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c101011071.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c101011071.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c101011071.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c101011071.lvop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsLevelAbove(1) and tc:IsRelateToEffect(e) then
+		local lv=tc:GetOriginalLevel()
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CHANGE_LEVEL)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(lv*2)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/scripts/IGAS-JP/c101011072.lua
+++ b/scripts/IGAS-JP/c101011072.lua
@@ -1,0 +1,46 @@
+--メガリス・エマージョン
+
+--Scripted by mallu11
+function c101011072.initial_effect(c)
+	--activate
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_ACTIVATE)
+	e0:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e0)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(101011072,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetCountLimit(1,101011072)
+	e1:SetTarget(c101011072.sptg)
+	e1:SetOperation(c101011072.spop)
+	c:RegisterEffect(e1)
+end
+function c101011072.filter(c,e,tp)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x238) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+end
+function c101011072.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c101011072.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.IsExistingTarget(c101011072.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c101011072.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c101011072.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)~=0 then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetReset(RESET_EVENT+RESETS_REDIRECT)
+			e1:SetValue(LOCATION_DECKBOT)
+			tc:RegisterEffect(e1)
+		end
+	end
+end


### PR DESCRIPTION
Should add a new function in utility.lua：
function Auxiliary.RitualUltimateFilter2(c,filter,e,tp,m1,m2,level_function,greater_or_equal,tc)
	if bit.band(c:GetType(),0x81)~=0x81 or (filter and not filter(c,e,tp)) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
	local mg=m1:Filter(Card.IsCanBeRitualMaterial,c,c)
	if m2 then
		mg:Merge(m2)
	end
	if c.mat_filter then
		mg=mg:Filter(c.mat_filter,c,tp)
	else
		mg:RemoveCard(c)
	end
	if not mg:IsContains(tc) then return false end
	local lv=level_function(c)
	if tc and tc:IsCanBeRitualMaterial(c) then
		Duel.SetSelectedCard(tc)
	end
	Auxiliary.GCheckAdditional=Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
	local res=mg:CheckSubGroup(Auxiliary.RitualCheck,1,lv,tp,c,lv,greater_or_equal)
	Auxiliary.GCheckAdditional=nil
	return res
end