### PR TITLE
fix ペンデュラム・ディメンション

### DIFF
--- a/scripts/DP23-JP/c100423049.lua
+++ b/scripts/DP23-JP/c100423049.lua
@@ -20,6 +20,7 @@ function c100423049.initial_effect(c)
 end
 function c100423049.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ) and c:GetMaterial():IsExists(Card.IsType,1,nil,TYPE_PENDULUM)
+	and (c:IsSummonType(SUMMON_TYPE_FUSION) or c:IsSummonType(SUMMON_TYPE_SYNCHRO) or c:IsSummonType(SUMMON_TYPE_XYZ) or c:GetSummonType()==SUMMON_TYPE_SPECIAL+1)
 end
 function c100423049.tgfilter1(c,e,tp,eg)
 	return eg:IsContains(c) and c:IsFaceup() and c:IsType(TYPE_FUSION) and Duel.IsExistingMatchingCard(c100423049.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetOriginalLevel())
@@ -49,7 +50,7 @@ function c100423049.spfilter5(c,e,tp,rank)
 	return c:IsType(TYPE_TUNER) and c:GetLevel()<=rank and (c:IsAbleToHand() or c:IsCanBeSpecialSummoned(e,0,tp,false,false))
 end
 function c100423049.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return rp==tp and eg:IsExists(c100423049.cfilter,1,nil)
+	return rp==tp and eg:IsExists(c100423049.cfilter,1,nil) and e:GetHandler():IsStatus(STATUS_EFFECT_ENABLED)
 end
 function c100423049.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local mz=Duel.GetLocationCount(tp,LOCATION_MZONE)   


### PR DESCRIPTION
Adding "SetValue(1)" in Auxiliary.AddContactFusionProcedure to mark the special summon uses the fusion material.