### PR TITLE
fix 超魔導師－ブラック・マジシャンズ

### DIFF
--- a/scripts/DP23-JP/c100423001.lua
+++ b/scripts/DP23-JP/c100423001.lua
@@ -45,7 +45,7 @@ function c100423001.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if Duel.Draw(tp,1,REASON_EFFECT)~=0 then
 		local dc=Duel.GetOperatedGroup():GetFirst()
-		if dc:IsSSetable()
+		if dc:IsType(TYPE_SPELL+TYPE_TRAP) and dc:IsSSetable()
 			and Duel.SelectYesNo(tp,aux.Stringid(100423001,0)) then
 			Duel.SSet(tp,dc)
 			if dc:IsType(TYPE_QUICKPLAY) then


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22883&keyword=&tag=-1&request_locale=ja
「超魔導師－ブラック・マジシャンズ」のモンスター効果によってドローしたカードが魔法・罠カードだった場合には、自分フィールドにセットする処理を行う事ができます。

「トイ・マジシャン」はモンスターカードですので、『このカードは魔法カード扱いとして手札から魔法＆罠カードゾーンにセットする事ができる』モンスター効果を適用して、フィールドにセットする事はできません。