### PR TITLE
fix

### DIFF
--- a/scripts/ETCO-JP/c101012002.lua
+++ b/scripts/ETCO-JP/c101012002.lua
@@ -34,10 +34,14 @@ function c101012002.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c101012002.atktg(e,c)
-	return c:IsFaceup() and c:IsType(TYPE_LINK) and not c:IsSetCard(0x23c) and c:GetLinkedGroup():IsContains(e:GetHandler())
+	local lg1=c:GetLinkedGroup()
+	local lg2=e:GetHandler():GetLinkedGroup()
+	return c:IsFaceup() and c:IsType(TYPE_LINK) and not c:IsSetCard(0x23c)
+		and (lg1 and lg1:IsContains(e:GetHandler()) or lg2 and lg2:IsContains(c))
 end
 function c101012002.desfilter(c)
-	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousTypeOnField()&TYPE_LINK~=0 and c:IsPreviousSetCard(0x23c) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousTypeOnField()&TYPE_LINK~=0 and c:IsPreviousSetCard(0x23c)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c101012002.descon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c101012002.desfilter,1,nil)

--- a/scripts/ETCO-JP/c101012027.lua
+++ b/scripts/ETCO-JP/c101012027.lua
@@ -39,7 +39,7 @@ function c101012027.tgcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c101012027.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE+LOCATION_HAND)>0 end
-	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,0,LOCATION_MZONE+LOCATION_HAND)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,1-tp,LOCATION_MZONE+LOCATION_HAND)
 end
 function c101012027.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsType,1-tp,LOCATION_MZONE+LOCATION_HAND,0,nil,TYPE_MONSTER)

--- a/scripts/ETCO-JP/c101012045.lua
+++ b/scripts/ETCO-JP/c101012045.lua
@@ -71,7 +71,7 @@ function c101012045.spop1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c101012045.cfilter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and (c:IsLocation(LOCATION_GRAVE) or (c:IsLocation(LOCATION_REMOVED) and c:IsFaceup()))
-		and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REDIRECT) and c:GetReasonPlayer()==tp and c:GetPreviousControler()==1-tp
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==tp and c:GetPreviousControler()==1-tp
 end
 function c101012045.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c101012045.cfilter,1,nil,tp) and not eg:IsContains(e:GetHandler())

--- a/scripts/ETCO-JP/c101012052.lua
+++ b/scripts/ETCO-JP/c101012052.lua
@@ -90,7 +90,7 @@ function c101012052.spop1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c101012052.regcon1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsReason(REASON_DESTROY) and rp==1-tp
+	return c:IsReason(REASON_DESTROY) and rp==1-tp and c:GetPreviousControler()==tp
 end
 function c101012052.regop1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/scripts/ETCO-JP/c101012055.lua
+++ b/scripts/ETCO-JP/c101012055.lua
@@ -45,6 +45,7 @@ function c101012055.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c101012055.spop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	local zone=bit.band(e:GetHandler():GetLinkedZone(tp),0x1f)
 	if tc:IsRelateToEffect(e) and zone~=0 then
@@ -53,7 +54,8 @@ function c101012055.spop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c101012055.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsReason(REASON_DESTROY) and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp)) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsSummonType(SUMMON_TYPE_LINK)
+	return (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp))
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsSummonType(SUMMON_TYPE_LINK)
 end
 function c101012055.thfilter(c)
 	return c:IsDefenseBelow(1500) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22960
Question
相手が「混沌の黒魔術師」の召喚に成功した際に、自分が発動した「狡猾な落とし穴」の効果によって、相手の「混沌の黒魔術師」は破壊され、自身の『③』のモンスター効果によって除外されました。

この場合、自分は「アロメルスの蟲惑魔」の『③』のモンスター効果を発動する事はできますか？
Answer
質問の状況の場合でも、「アロメルスの蟲惑魔」の『③』のモンスター効果を発動できます。

その場合、除外されている相手の「混沌の黒魔術師」を対象として発動し、自分のモンスターゾーンに特殊召喚する事になります。