### PR TITLE
Add setcode for Chaos Phantom

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -4,9 +4,6 @@
 #victory reason
 #counters
 #setnames
-!setname 0x23c Code Breaker
-!setname 0x23d Barbaros
-!setname 0x23e Nemesis
 !setname 0x23f Adamatia
 !setname 0x240 Plunder Patroll
 !setname 0x241 Chaos Phantom

--- a/strings.conf
+++ b/strings.conf
@@ -9,3 +9,4 @@
 !setname 0x23e Nemesis
 !setname 0x23f Adamatia
 !setname 0x240 Plunder Patroll
+!setname 0x241 Chaos Phantom


### PR DESCRIPTION
Mercury pre-data is already using this setcode. The strings.conf just isn't updated in this repo.
!setname 0x23f 魔救
!setname 0x240 巡掠海魔
!setname 0x241 幻魔