### PR TITLE
fix Myutant Blast

### DIFF
--- a/scripts/PHRA-EN/c101102094.lua
+++ b/scripts/PHRA-EN/c101102094.lua
@@ -83,7 +83,7 @@ function c101102094.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c101102094.sptgfilter(c,e,tp,attr)
-	return c:GetOriginalAttribute()~=attr and c:IsSetCard(0x258) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:GetOriginalAttribute()~=attr and c:IsLevel(8) and c:IsSetCard(0x258) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c101102094.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then


### PR DESCRIPTION
@mercury233 
Myutant Blast
While this card is equipped to a monster: You can banish this card; send the monster this card was equipped to the GY, and if you do, Special Summon 1 Level 8 "Myutant" monster with a different original Attribute from your hand or Deck. You can only use this effect of "Myutant Blast" once per turn.

>1 Level 8 "Myutant" monster with a different original Attribute

The previous PR is on the wrong branch, so I open a new one.