### PR TITLE
Update c101105076.lua

### DIFF
--- a/scripts/DAMA-JP/c101105076.lua
+++ b/scripts/DAMA-JP/c101105076.lua
@@ -109,7 +109,7 @@ function c101105076.naop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local ec=e:GetHandler():GetEquipTarget()
 	if Duel.NegateAttack()~=0 and ec then
-		Duel.GetControl(ec,1-tp,PHASE_BATTLE,1)
+		Duel.GetControl(ec,1-ec:GetControler(),PHASE_BATTLE,1)
 	end
 end
 function c101105076.thcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
@mercury233 
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=16265&request_locale=ja
②：装備モンスターのコントローラーによって以下の効果を発動できる。
●自分：１ターンに１度、相手モンスターの攻撃宣言時に発動できる。その攻撃を無効にし、バトルフェイズ終了時まで装備モンスターのコントロールを変更する。
●相手：装備モンスターが効果を発動した時に発動できる。装備モンスターを持ち主の手札に戻す。 

「コントロールを変更する」should be:
The control of X is sent to the opponent of X, not the opponent of activating player.
