### PR TITLE
fix 妖眼の相剣師

### DIFF
--- a/scripts/DAMA-JP/c101105009.lua
+++ b/scripts/DAMA-JP/c101105009.lua
@@ -29,7 +29,7 @@ function c101105009.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c101105009.cfilter(c)
-	return c:IsFaceup() and c:IsDisabled()
+	return c:IsFaceup() and c:IsDisabled() and not c:IsType(TYPE_NORMAL)
 end
 function c101105009.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()

--- a/scripts/DAMA-JP/c101105009.lua
+++ b/scripts/DAMA-JP/c101105009.lua
@@ -29,7 +29,7 @@ function c101105009.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c101105009.cfilter(c)
-	return c:IsFaceup() and c:IsDisabled() and not c:IsType(TYPE_NORMAL)
+	return c:IsFaceup() and c:IsDisabled() and c:IsType(TYPE_EFFECT)
 end
 function c101105009.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()


### PR DESCRIPTION
fix: if normal monster has on the field, 妖眼の相剣師 can activate.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16198
> ■『①』は手札で発動できる誘発即時効果です。（効果が無効化されている表側表示の**効果モンスター**が、自分または相手のフィールドに存在する場合に発動できます。）