### PR TITLE
fix BODE

### DIFF
--- a/scripts/BODE-JP/c101106021.lua
+++ b/scripts/BODE-JP/c101106021.lua
@@ -1,4 +1,4 @@
---大魔鍵一マフテアル
+--大魔鍵－マフテアル
 --scripted by XyLeN
 function c101106021.initial_effect(c)
 	--synchro and xyz limit

--- a/scripts/BODE-JP/c101106029.lua
+++ b/scripts/BODE-JP/c101106029.lua
@@ -35,6 +35,7 @@ function c101106029.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and c:IsFaceup() then
 		local atk=tc:GetBaseAttack()
+		if atk<=0 then return end
 		local race=tc:GetOriginalRace()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/scripts/BODE-JP/c101106062.lua
+++ b/scripts/BODE-JP/c101106062.lua
@@ -1,4 +1,4 @@
---魔鍵關争
+--魔鍵闘争
 --scripted by XyLeN
 function c101106062.initial_effect(c)
 	--Activate


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23304&keyword=&tag=-1
> なお、その処理によって元々の攻撃力が０や？のモンスターを破壊することもできますが、『その元々の攻撃力分このカードの攻撃力をアップする』処理によって攻撃力はアップしません。そのため、『このカードの種族を破壊したモンスターの元々の種族と同じにできる』処理も適用できません。