### PR TITLE
fix 冥府の執行者 プルート

### DIFF
--- a/scripts/SR12-JP/c100312040.lua
+++ b/scripts/SR12-JP/c100312040.lua
@@ -60,10 +60,10 @@ function c100312040.posfilter(c)
 end
 function c100312040.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c100312040.posfilter(chkc) and chkc~=c end
-	if chk==0 then return Duel.IsExistingTarget(c100312040.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c100312040.posfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c100312040.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,c100312040.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,c)
+	local g=Duel.SelectTarget(tp,c100312040.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)
 end
 function c100312040.posop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
https://yugioh-wiki.net/index.php?%A1%D4%CC%BD%C9%DC%A4%CE%BC%B9%B9%D4%BC%D4%20%A5%D7%A5%EB%A1%BC%A5%C8%A1%D5
(1)：１ターンに１度、自分の墓地からモンスター１体を除外し、
フィールドの効果モンスター１体を対象として発動できる。
そのモンスターを裏側守備表示にする。
フィールドまたは墓地に「天空の聖域」が存在する場合、この効果は相手ターンでも発動できる。
