### PR TITLE
Fix "Beetrooper Formation"

### DIFF
--- a/scripts/DAMA-EN/c101105090.lua
+++ b/scripts/DAMA-EN/c101105090.lua
@@ -48,9 +48,9 @@ function c101105090.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_CANNOT_ATTACK)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1,true)
-		Duel.SetLP(tp,Duel.GetLP(tp)-tc:GetBaseAttack())
 	end
 	Duel.SpecialSummonComplete()
+	Duel.SetLP(tp,Duel.GetLP(tp)-tc:GetBaseAttack())
 end
 function c101105090.cfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsPreviousLocation(LOCATION_MZONE)


### PR DESCRIPTION
Decreases user's LP regardless of the 1st effect's Summon succeeding