### PR TITLE
fix 不朽の七皇

### DIFF
--- a/scripts/DP26-JP/c100426007.lua
+++ b/scripts/DP26-JP/c100426007.lua
@@ -58,6 +58,7 @@ function c100426007.operation(e,tp,eg,ep,ev,re,r,rp)
 	local s=e:GetLabel()
 	local tc=Duel.GetFirstTarget()
 	if s==0 then
+		if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 		local sg=Duel.GetMatchingGroup(c100426007.disfilter,tp,0,LOCATION_MZONE,nil,tc:GetAttack())
 		if sg:GetCount()>0 then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISABLE)
@@ -85,11 +86,12 @@ function c100426007.operation(e,tp,eg,ep,ev,re,r,rp)
 			local og=tc:GetOverlayGroup()
 			if og:GetCount()>0 and Duel.SendtoGrave(og,REASON_EFFECT)>0
 				and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-				and Duel.IsExistingMatchingCard(c100426007.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
+				and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c100426007.spfilter),tp,LOCATION_GRAVE,0,1,nil,e,tp)
 				and Duel.SelectYesNo(tp,aux.Stringid(100426007,2)) then
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local ng=Duel.SelectMatchingCard(tp,c100426007.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+				local ng=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c100426007.spfilter),tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 				if ng:GetCount()>0 then
+					Duel.BreakEffect()
 					Duel.SpecialSummon(ng,0,tp,tp,false,false,POS_FACEUP)
 				end
 			end


### PR DESCRIPTION
fix 1: if target monster has not face-up on the field, 不朽の七皇's effect resolve.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23425&keyword=&tag=-1
> 『●対象のモンスターの攻撃力以下の攻撃力を持つ相手フィールドのモンスター１体を選び、その効果をターン終了時まで無効にする』効果の処理時に対象のモンスターが裏側守備表示になった場合、**対象のモンスターの攻撃力を参照できませんので、効果処理は行われません**。

fix 2: 『対象のモンスターのX素材を全て取り除く』 and 『自分の墓地から「No.」Xモンスター１体を選んで特殊召喚』 are the same.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17045
> ■２つ目の『●』の処理時に、『対象のモンスターのX素材を全て取り除く』処理を行います。その後、『自分の墓地から「No.」Xモンスター１体を選んで特殊召喚』の処理を行うことができます。（**これらの処理は同時に行われません**。）

fix 3: missing check necrovalley.