### PR TITLE
fix ENウェーブ

### DIFF
--- a/scripts/POTE-JP/c101109053.lua
+++ b/scripts/POTE-JP/c101109053.lua
@@ -37,11 +37,9 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.dspconfilter(c,tp)
-	if c:IsPreviousLocation(LOCATION_ONFIELD) then
-		return c:IsPreviousSetCard(0x3008) and c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
-	else
-		return c:IsSetCard(0x3008) and c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
-	end
+	return c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+		and (c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousSetCard(0x3008)
+			or not c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsSetCard(0x3008))
 end
 function s.dspcon(e,tp,eg,ep,ev,re,r,rp)
 	return r==REASON_FUSION and eg:IsExists(s.dspconfilter,1,nil,tp)

--- a/scripts/POTE-JP/c101109053.lua
+++ b/scripts/POTE-JP/c101109053.lua
@@ -1,4 +1,4 @@
---ＥＮ ウェーブ
+--ENウェーブ
 --Script by JSY1728
 local s,id,o=GetID()
 function s.initial_effect(c)
@@ -37,7 +37,11 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.dspconfilter(c,tp)
-	return c:IsSetCard(0x3008) and c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+	if c:IsPreviousLocation(LOCATION_ONFIELD) then
+		return c:IsPreviousSetCard(0x3008) and c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+	else
+		return c:IsSetCard(0x3008) and c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+	end
 end
 function s.dspcon(e,tp,eg,ep,ev,re,r,rp)
 	return r==REASON_FUSION and eg:IsExists(s.dspconfilter,1,nil,tp)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23634&keyword=&tag=-1
> モンスターゾーンでカード名が「E・HERO」モンスターになっているモンスターが融合素材として墓地へ送られた場合でも、「[ENウェーブ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17456)」の『①』の効果を発動する条件である『自分の「E・HERO」モンスターが融合モンスターの融合召喚の素材になり、墓地へ送られた場合または除外された場合』は満たされます。