### PR TITLE
Update 倶利伽羅天童

### DIFF
--- a/scripts/POTE-JP/c101109031.lua
+++ b/scripts/POTE-JP/c101109031.lua
@@ -1,6 +1,6 @@
 --倶利伽羅天童
 --Scripted by mallu11
-local s,id=GetID()
+local s,id,o=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
 	--special summon condition
@@ -44,21 +44,21 @@ function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not rc:IsRelateToEffect(re) or not re:IsActiveType(TYPE_MONSTER) then return end
 	local p,loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION)
-	if loc==LOCATION_MZONE and rc:GetFlagEffect(id+1-p)==0 then
-		rc:RegisterFlagEffect(id+1-p,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END,0,1)
+	if loc==LOCATION_MZONE and rc:GetFlagEffect(id+o+p)==0 then
+		rc:RegisterFlagEffect(id+o+p,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END,0,1)
 	end
 end
-function s.rfilter(c,tp)
-	return c:IsFaceup() and c:GetFlagEffect(id+tp)>0
+function s.rfilter(c,p)
+	return c:IsFaceup() and c:GetFlagEffect(id+o+p)>0
 end
 function s.sprcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,1-tp)
 	return rg:GetCount()>0 and rg:FilterCount(Card.IsReleasable,nil)==rg:GetCount() and aux.mzctcheck(rg,tp)
 end
 function s.sprop(e,tp,eg,ep,ev,re,r,rp,c)
-	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,1-tp)
 	Duel.Release(rg,REASON_COST)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/scripts/POTE-JP/c101109031.lua
+++ b/scripts/POTE-JP/c101109031.lua
@@ -1,7 +1,7 @@
 --倶利伽羅天童
-
 --Scripted by mallu11
-function c101109031.initial_effect(c)
+local s,id=GetID()
+function s.initial_effect(c)
 	c:EnableReviveLimit()
 	--special summon condition
 	local e1=Effect.CreateEffect(c)
@@ -15,50 +15,50 @@ function c101109031.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e2:SetCode(EFFECT_SPSUMMON_PROC)
 	e2:SetRange(LOCATION_HAND)
-	e2:SetCondition(c101109031.sprcon)
-	e2:SetOperation(c101109031.sprop)
+	e2:SetCondition(s.sprcon)
+	e2:SetOperation(s.sprop)
 	c:RegisterEffect(e2)
 	--special summon
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(101109031,0))
+	e3:SetDescription(aux.Stringid(id,0))
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e3:SetCode(EVENT_PHASE+PHASE_END)
 	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1,101109031)
-	e3:SetCondition(c101109031.spcon)
-	e3:SetTarget(c101109031.sptg)
-	e3:SetOperation(c101109031.spop)
+	e3:SetCountLimit(1,id)
+	e3:SetCondition(s.spcon)
+	e3:SetTarget(s.sptg)
+	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
-	if not c101109031.global_check then
-		c101109031.global_check=true
+	if not s.global_check then
+		s.global_check=true
 		local ge1=Effect.CreateEffect(c)
 		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		ge1:SetCode(EVENT_CHAIN_SOLVED)
-		ge1:SetOperation(c101109031.checkop)
+		ge1:SetOperation(s.checkop)
 		Duel.RegisterEffect(ge1,0)
 	end
 end
-function c101109031.checkop(e,tp,eg,ep,ev,re,r,rp)
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not rc:IsRelateToEffect(re) or not re:IsActiveType(TYPE_MONSTER) then return end
 	local p,loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION)
-	if loc==LOCATION_MZONE and rc:GetFlagEffect(101109032-p)==0 then
-		rc:RegisterFlagEffect(101109032-p,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END,0,1)
+	if loc==LOCATION_MZONE and rc:GetFlagEffect(id+1-p)==0 then
+		rc:RegisterFlagEffect(id+1-p,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END,0,1)
 	end
 end
-function c101109031.rfilter(c,tp)
-	return c:IsFaceup() and c:GetFlagEffect(101109031+tp)>0
+function s.rfilter(c,tp)
+	return c:IsFaceup() and c:GetFlagEffect(id+tp)>0
 end
-function c101109031.sprcon(e,c)
+function s.sprcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	local rg=Duel.GetMatchingGroup(c101109031.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
 	return rg:GetCount()>0 and rg:FilterCount(Card.IsReleasable,nil)==rg:GetCount() and aux.mzctcheck(rg,tp)
 end
-function c101109031.sprop(e,tp,eg,ep,ev,re,r,rp,c)
-	local rg=Duel.GetMatchingGroup(c101109031.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+function s.sprop(e,tp,eg,ep,ev,re,r,rp,c)
+	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
 	Duel.Release(rg,REASON_COST)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -67,21 +67,21 @@ function c101109031.sprop(e,tp,eg,ep,ev,re,r,rp,c)
 	e1:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD+RESET_DISABLE)
 	c:RegisterEffect(e1)
 end
-function c101109031.spcon(e,tp,eg,ep,ev,re,r,rp)
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
-function c101109031.spfilter(c,e,tp)
+function s.spfilter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c101109031.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and c101109031.spfilter(chkc,e,tp) end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and s.spfilter(chkc,e,tp) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(c101109031.spfilter,tp,0,LOCATION_GRAVE,1,nil,e,tp) end
+		and Duel.IsExistingTarget(s.spfilter,tp,0,LOCATION_GRAVE,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,c101109031.spfilter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
-function c101109031.spop(e,tp,eg,ep,ev,re,r,rp)
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
Now that we have the `GetID` function, the card ID, `101109031`, can be split from the flag effect ID which is being registered to monsters which activate their effects; yes, `101109031+1` is redundant, but the ID at the result, `101109032`, has a corresponding card: `Aussa the Earth Channeler`.