### PR TITLE
fix 悪醒師ナイトメルト

### DIFF
--- a/scripts/POTE-JP/c101109038.lua
+++ b/scripts/POTE-JP/c101109038.lua
@@ -26,7 +26,7 @@ end
 function c101109038.spfilter(c,mc,e,tp)
 	return c:IsLevel(mc:GetOriginalLevel()) and not c:IsOriginalCodeRule(mc:GetOriginalCodeRule())
 		and c:IsRace(mc:GetOriginalRace()) and c:IsAttribute(mc:GetOriginalAttribute())
-		and c:IsAttack(mc:GetBaseAttack()) and c:IsDefense(mc:GetBaseDefense())
+		and c:IsAttack(mc:GetTextAttack()) and c:IsDefense(mc:GetTextDefense())
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and (not c:IsLocation(LOCATION_EXTRA) and Duel.GetMZoneCount(tp,c)>0
 			or c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,mc,c)>0)

--- a/scripts/POTE-JP/c101109038.lua
+++ b/scripts/POTE-JP/c101109038.lua
@@ -26,7 +26,7 @@ end
 function c101109038.spfilter(c,mc,e,tp)
 	return c:IsLevel(mc:GetOriginalLevel()) and not c:IsOriginalCodeRule(mc:GetOriginalCodeRule())
 		and c:IsRace(mc:GetOriginalRace()) and c:IsAttribute(mc:GetOriginalAttribute())
-		and c:IsAttack(mc:GetTextAttack()) and c:IsDefense(mc:GetTextDefense())
+		and c:GetTextAttack()==mc:GetTextAttack() and c:GetTextDefense()==mc:GetTextDefense()
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and (not c:IsLocation(LOCATION_EXTRA) and Duel.GetMZoneCount(tp,c)>0
 			or c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,mc,c)>0)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17440
> ■攻撃力が？のモンスターをリリースした場合、**攻撃力が？のモンスターを同じ攻撃力のモンスターとして特殊召喚できます**。守備力についても同様です。