### PR TITLE
workaround fix A宝玉獣 ルビー・カーバンクル

### DIFF
--- a/scripts/AC02-JP/c100290010.lua
+++ b/scripts/AC02-JP/c100290010.lua
@@ -60,13 +60,18 @@ function c100290010.filter(c,e,sp)
 end
 function c100290010.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+	if c:IsRelateToEffect(e) and Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) then
 		local ct=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		if ct<=0 then return end
+		if ct<=0 then
+			Duel.SpecialSummonComplete()
+			return
+		end
 		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
 		local g=Duel.GetMatchingGroup(c100290010.filter,tp,LOCATION_SZONE,0,nil,e,tp)
 		local gc=g:GetCount()
 		if gc>0 and Duel.SelectYesNo(tp,aux.Stringid(100290010,0)) then
+			Duel.DisableSelfDestroyCheck()
+			Duel.SpecialSummonComplete()
 			Duel.BreakEffect()
 			if gc<=ct then
 				Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
@@ -75,6 +80,9 @@ function c100290010.spop(e,tp,eg,ep,ev,re,r,rp)
 				local sg=g:Select(tp,ct,ct,nil)
 				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			end
+			Duel.DisableSelfDestroyCheck(false)
+		else
+			Duel.SpecialSummonComplete()
 		end
 	end
 end

--- a/scripts/AC02-JP/c100290010.lua
+++ b/scripts/AC02-JP/c100290010.lua
@@ -60,27 +60,31 @@ function c100290010.filter(c,e,sp)
 end
 function c100290010.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) then
-		local ct=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		if ct<=0 then
-			Duel.SpecialSummonComplete()
-			return
-		end
-		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
-		local g=Duel.GetMatchingGroup(c100290010.filter,tp,LOCATION_SZONE,0,nil,e,tp)
-		local gc=g:GetCount()
-		if gc>0 and Duel.SelectYesNo(tp,aux.Stringid(100290010,0)) then
-			Duel.DisableSelfDestroyCheck()
-			Duel.SpecialSummonComplete()
-			Duel.BreakEffect()
-			if gc<=ct then
-				Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
-			else
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local sg=g:Select(tp,ct,ct,nil)
-				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+	if c:IsRelateToEffect(e) then
+		if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) then
+			local ct=Duel.GetLocationCount(tp,LOCATION_MZONE)
+			if ct<=0 then
+				Duel.SpecialSummonComplete()
+				return
 			end
-			Duel.DisableSelfDestroyCheck(false)
+			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
+			local g=Duel.GetMatchingGroup(c100290010.filter,tp,LOCATION_SZONE,0,nil,e,tp)
+			local gc=g:GetCount()
+			if gc>0 and Duel.SelectYesNo(tp,aux.Stringid(100290010,0)) then
+				Duel.DisableSelfDestroyCheck()
+				Duel.SpecialSummonComplete()
+				Duel.BreakEffect()
+				if gc<=ct then
+					Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+				else
+					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+					local sg=g:Select(tp,ct,ct,nil)
+					Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+				end
+				Duel.DisableSelfDestroyCheck(false)
+			else
+				Duel.SpecialSummonComplete()
+			end
 		else
 			Duel.SpecialSummonComplete()
 		end


### PR DESCRIPTION
Q.
フィールドゾーンに「アドバンスド・ダーク」が存在しない状況で、自分の魔法＆罠ゾーンに永続魔法カード扱いの「A宝玉獣 ルビー・カーバンクル」「A宝玉獣 アメジスト・キャット」「A宝玉獣 エメラルド・タートル」「A宝玉獣 トパーズ・タイガー」「A宝玉獣 アンバー・マンモス」の5枚が存在しています。また、自分のメインモンスターゾーンに「おジャマトークン」1体が存在し、空きが4つの状態です。
 
この状況で、自分が「A宝玉獣 ルビー・カーバンクル」の『③』効果を発動した場合、処理はどうなりますか？
下記の（1）（2）の処理はどちらが正しいですか？
（1）まず『このカードを特殊召喚する』処理によって「A宝玉獣 ルビー・カーバンクル」を特殊召喚し、ただちに自身の『①』効果により「A宝玉獣 ルビー・カーバンクル」は墓地へ送られます。メインモンスターゾーンの空きが4つになっています。
その後、『自分の魔法＆罠ゾーンの「A宝玉獣」モンスターカードを可能な限り特殊召喚できる』処理によって、「A宝玉獣 アメジスト・キャット」「A宝玉獣 エメラルド・タートル」「A宝玉獣 トパーズ・タイガー」「A宝玉獣 アンバー・マンモス」の4枚を全て特殊召喚します。
その効果処理を終了した時点から、「A宝玉獣 アメジスト・キャット」「A宝玉獣 エメラルド・タートル」「A宝玉獣 トパーズ・タイガー」「A宝玉獣 アンバー・マンモス」を全て墓地へ送られます。
（2）まず『このカードを特殊召喚する』処理によって「A宝玉獣 ルビー・カーバンクル」を特殊召喚し、自分のメインモンスターゾーンの空きが3つになっています。
その後、『自分の魔法＆罠ゾーンの「A宝玉獣」モンスターカードを可能な限り特殊召喚できる』処理によって、「A宝玉獣 アメジスト・キャット」「A宝玉獣 エメラルド・タートル」「A宝玉獣 トパーズ・タイガー」「A宝玉獣 アンバー・マンモス」の4枚のうち、3枚までを選んで特殊召喚します。
その効果処理を終了した時点から、「A宝玉獣 ルビー・カーバンクル」を含む「A宝玉獣」モンスターを全て墓地へ送られます。
A.
「A宝玉獣 ルビー・カーバンクル」が特殊召喚され、「A宝玉獣」モンスターを３体まで特殊召喚できますが、その処理後に、特殊召喚された４体の「A宝玉獣」モンスターは墓地へ送られます。
 
Q.
フィールドゾーンに「アドバンスド・ダーク」が存在しない状況で、自分の魔法＆罠ゾーンに永続魔法カード扱いの「A宝玉獣 ルビー・カーバンクル」「A宝玉獣 アメジスト・キャット」の2枚が存在しています。また、自分のメインモンスターゾーンに「おジャマトークン」4体が存在し、空きが1つしかない状態です。
この状況で、自分が「A宝玉獣 ルビー・カーバンクル」の『③』効果を発動した場合、処理はどうなりますか？「A宝玉獣 アメジスト・キャット」を特殊召喚することはできますか？
A.
「A宝玉獣 ルビー・カーバンクル」が特殊召喚され、『③』の効果処理が完了になります。
 
その後、『①』の効果が適用され、「A宝玉獣 ルビー・カーバンクル」は墓地に送られます。