### PR TITLE
fix 銃の忍者－火光

### DIFF
--- a/scripts/DABL-JP/c101110018.lua
+++ b/scripts/DABL-JP/c101110018.lua
@@ -50,18 +50,18 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
 	end
 end
+function s.tfilter(c,tp)
+	return c:IsControler(tp) and (c:IsLocation(LOCATION_ONFIELD) and c:IsFaceup() and c:IsSetCard(0x2b) or c:IsLocation(LOCATION_MZONE) and c:IsPosition(POS_FACEDOWN_DEFENSE))
+end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	if rp~=1-tp or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	if not g or g:GetCount()~=1 then return false end
-	local tc=g:GetFirst()
-	e:SetLabelObject(tc)
-	return tc:IsOnField() and tc:IsControler(tp)
-		and (tc:IsFaceup() and tc:IsSetCard(0x2b) or tc:IsPosition(POS_FACEDOWN_DEFENSE))
+	return g and g:GetCount()==1 and g:IsExists(s.tfilter,1,nil,tp)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	local tc=e:GetLabelObject()
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	local tc=g:GetFirst()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) and tc and tc:IsAbleToHand() end
 	Duel.SetTargetCard(tc)


### PR DESCRIPTION
@mercury233 

銃の忍者－火光
このカード名の①②の効果はそれぞれ１ターンに１度しか使用できない。
①：このカードが召喚・特殊召喚・リバースした場合に発動できる。自分の手札・墓地から「銃の忍者－火光」以外の「忍者」モンスター１体を選んで裏側守備表示で特殊召喚する。
②：このカードが墓地に存在し、自分フィールドの、「忍者」カード１枚のみまたは裏側守備表示モンスター１体のみを対象とする相手の効果が発動した時に発動できる。このカードを裏側守備表示で特殊召喚し、その対象となったカードを持ち主の手札に戻す。 

Fix: 
Now the 2nd effect cannot be activated when a face-down spell/trap becomes a target.
