### PR TITLE
fix クシャトリラ・アライズハート

### DIFF
--- a/scripts/PHHY-JP/c101111046.lua
+++ b/scripts/PHHY-JP/c101111046.lua
@@ -74,27 +74,14 @@ function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabelObject(nil)
 	c:RegisterFlagEffect(id,RESET_CHAIN,0,1)
 end
-function s.mtfilter1(c,tp)
-	return c:IsCanOverlay() and (c:IsFaceup() or c:IsControler(tp))
-end
-function s.mtfilter2(c)
-	return c:IsCanOverlay() and c:IsFacedown()
-end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not (c:IsRelateToChain() and c:IsType(TYPE_XYZ)) then return end
-	local mg1=Duel.GetMatchingGroup(s.mtfilter1,tp,LOCATION_REMOVED,LOCATION_REMOVED,nil,tp)
-	local mg2=Duel.GetMatchingGroup(s.mtfilter2,tp,0,LOCATION_REMOVED,nil)
-	if #mg1==0 and #mg2==0 then return end
-	local g
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPTION)
-	if #mg1==0 or #mg2>0 and Duel.SelectOption(tp,aux.Stringid(id,3),aux.Stringid(id,4))==1 then
-		g=mg2:RandomSelect(tp,1)
-	else
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		g=mg1:Select(tp,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+	local mg=Duel.SelectMatchingCard(tp,Card.IsCanOverlay,tp,LOCATION_REMOVED,LOCATION_REMOVED,1,1,nil)
+	if #mg>0 then
+		Duel.Overlay(c,mg)
 	end
-	Duel.Overlay(c,g)
 end
 function s.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,3,REASON_COST) end

--- a/scripts/PHHY-JP/c101111046.lua
+++ b/scripts/PHHY-JP/c101111046.lua
@@ -65,8 +65,13 @@ end
 function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		return c:GetFlagEffect(id)==0
+		--workaround check of only 1 activation
+		local g=e:GetLabelObject()
+		local res=c:GetFlagEffect(id)==0 and (g==nil or g:Equal(eg))
+		if res then e:SetLabelObject(eg) end
+		return res
 	end
+	e:SetLabelObject(nil)
 	c:RegisterFlagEffect(id,RESET_CHAIN,0,1)
 end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)

--- a/scripts/PHHY-JP/c101111046.lua
+++ b/scripts/PHHY-JP/c101111046.lua
@@ -65,13 +65,8 @@ end
 function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		--workaround check of only 1 activation
-		local g=e:GetLabelObject()
-		local res=c:GetFlagEffect(id)==0 and (g==nil or g:Equal(eg))
-		if res then e:SetLabelObject(eg) end
-		return res
+		return c:GetFlagEffect(id)==0
 	end
-	e:SetLabelObject(nil)
 	c:RegisterFlagEffect(id,RESET_CHAIN,0,1)
 end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
@mercury233 
There are many effects which can select a face-down banished card:
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12195&request_locale=ja
PSYフレームロード・Ω

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19897&keyword=&tag=-1&request_locale=ja
バージェストマ・レアンコイリア

https://yugioh-wiki.net/index.php?%A1%D4%A5%AF%A5%B7%A5%E3%A5%C8%A5%EA%A5%E9%A1%A6%A5%A2%A5%E9%A5%A4%A5%BA%A5%CF%A1%BC%A5%C8%A1%D5
クシャトリラ・アライズハート
(2)：カードが除外される度に発動する（同一チェーン上では１度まで）。
除外されているカード１枚を選んでこのカードのＸ素材とする。

No evidence shows that the selection should be random.