### PR TITLE
fix コズミック・クェーサー・ドラゴン

### DIFF
--- a/scripts/DUNE-JP/c101201203.lua
+++ b/scripts/DUNE-JP/c101201203.lua
@@ -21,7 +21,6 @@ function s.initial_effect(c)
 	e2:SetCountLimit(1)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CANNOT_INACTIVATE+EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCondition(s.discon)
 	e2:SetTarget(s.distg)
 	e2:SetOperation(s.disop)
 	c:RegisterEffect(e2)
@@ -29,7 +28,6 @@ function s.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_MATERIAL_CHECK)
 	e3:SetValue(s.valcheck)
-	e3:SetLabelObject(e2)
 	c:RegisterEffect(e3)
 	--special summon
 	local e4=Effect.CreateEffect(c)
@@ -48,16 +46,14 @@ s.material_type=TYPE_SYNCHRO
 function s.synlimit(e,se,sp,st)
 	return st&SUMMON_TYPE_SYNCHRO==SUMMON_TYPE_SYNCHRO and not se
 end
-function s.discon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO) and e:GetLabel()>0
-end
 function s.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local ct=e:GetLabel()
 	local c=e:GetHandler()
-	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and aux.NegateAnyFilter(chkc) and chkc~=c end
-	if chk==0 then return Duel.IsExistingTarget(aux.NegateAnyFilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
+	local ct=1
+	if c:GetFlagEffectLabel(id) then ct=c:GetFlagEffectLabel(id) end
+	if chkc then return chkc:IsOnField() and aux.NegateAnyFilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(aux.NegateAnyFilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISABLE)
-	local g=Duel.SelectTarget(tp,aux.NegateAnyFilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,ct,c)
+	local g=Duel.SelectTarget(tp,aux.NegateAnyFilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,ct,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,ct,0,0)
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)
@@ -91,7 +87,7 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.valcheck(e,c)
-	e:GetLabelObject():SetLabel(c:GetMaterialCount()+1)
+	c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD,0,1,c:GetMaterialCount()+1)
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18824&request_locale=ja
①：１ターンに１度、このカードのS素材としたモンスターの数＋１枚までフィールドの表側表示カードを対象として発動できる（この効果の発動と効果は無効化されない）。そのカードの効果を無効にする。

【①の効果について】
■モンスターゾーンで発動できる起動効果です。
■シンクロ素材としたモンスターの数を参照できない場合（シンクロ召喚によって特殊召喚されていない場合など）でも発動できます。その場合、対象に選択できるカードの枚数は１枚です。
■複数枚のカードを対象として発動した処理時に、対象のカードの一部が対象から外れた場合でも、残りの対象のカードについて処理を行います。

1. Wrong `chkc` condition.
2. 1st effect can target itself.


Test
[test_material.zip](https://github.com/Fluorohydride/ygopro-pre-script/files/11406677/test_material.zip)

