### PR TITLE
fix ヴィサス＝アムリターラ

### DIFF
--- a/scripts/DUNE-JP/c101201039.lua
+++ b/scripts/DUNE-JP/c101201039.lua
@@ -53,18 +53,18 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,nil,tp,LOCATION_MZONE,0,1,1,nil)
-	if #g==0 then return end
-	Duel.HintSelection(g)
-	if Duel.Destroy(g,REASON_EFFECT)~=0 then
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetCode(EFFECT_UPDATE_ATTACK)
-		e1:SetTargetRange(LOCATION_MZONE,0)
-		e1:SetTarget(s.atktg)
-		e1:SetValue(800)
-		e1:SetReset(RESET_PHASE+PHASE_END)
-		Duel.RegisterEffect(e1,tp)
+	if #g>0 then
+		Duel.HintSelection(g)
+		Duel.Destroy(g,REASON_EFFECT)
 	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetTargetRange(LOCATION_MZONE,0)
+	e1:SetTarget(s.atktg)
+	e1:SetValue(800)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
 end
 function s.atktg(e,c)
 	return c:IsType(TYPE_SYNCHRO)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18826&request_locale=ja
③：自分メインフェイズに発動できる。自分フィールドのモンスター１体を破壊する。このターン中は自分フィールドのSモンスターの攻撃力が８００アップする。 

【③の効果について】
■モンスターゾーンで発動できる起動効果です。
■処理時に、『自分フィールドのモンスター１体を破壊する』処理を行います。また、処理時に、『このターン中は自分フィールドのSモンスターの攻撃力が８００アップする』状態になります。
■この効果の処理時以降に自分のモンスターゾーンに表側表示で存在するようになったシンクロモンスターにも、このターン中は『攻撃力が８００アップする』効果が適用されます。 

