### PR TITLE
change setcode 0x21

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -11,3 +11,5 @@
 !setname 0x2084 Battlin' Boxing
 !setname 0x298 Visas
 !setname 0x299 Counter
+!setname 0x21 Earthbound
+!setname 0x1021 Earthbound Immortal


### PR DESCRIPTION
https://yugioh-wiki.net/index.php?%A1%D4%C3%CF%C7%FB%BC%FC%BF%CD%20%A5%B0%A5%E9%A5%F3%A5%C9%A1%A6%A5%AD%A1%BC%A5%D1%A1%BC%A1%D5
(1)：このカードが召喚・特殊召喚した場合に発動できる。
「地縛囚人 グランド・キーパー」を除く、レベル５以下の「地縛」モンスター１体を自分のデッキ・墓地から特殊召喚する。

new setcode
!setname 0x21 Earthbound
!setname 0x1021 Earthbound Immortal