### PR TITLE
add setcodes

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -4,3 +4,6 @@
 #victory reason
 #counters
 #setnames
+!setname 0x3 Horus
+!setname 0x200 Veda
+!setname 0x201 Heart


### PR DESCRIPTION
The setcode for "Horus" was previously used by `Horus' Servant` until it was changed to use the Horus LV Dragons' codes, instead.