### PR TITLE
Add HintTiming for 炎王神獣 キリン

### DIFF
--- a/scripts/SR14-JP/c100314002.lua
+++ b/scripts/SR14-JP/c100314002.lua
@@ -14,6 +14,7 @@ function s.initial_effect(c)
 	e1:SetCondition(s.spscon)
 	e1:SetTarget(s.spstg)
 	e1:SetOperation(s.spsop)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
 	c:RegisterEffect(e1)
 	--spsummon
 	local e2=Effect.CreateEffect(c)


### PR DESCRIPTION
炎王神獣 キリン's effect could be activate during both player's main phase. Add HintTiming for it.