### PR TITLE
add 100212002,03

### DIFF
--- a/scripts/PHNI-JP/c101203059.lua
+++ b/scripts/PHNI-JP/c101203059.lua
@@ -1,0 +1,81 @@
+--幾星霜
+--Scripted by zengsxing
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,id)
+	e1:SetCondition(s.conditon)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,id)
+	e2:SetCode(EVENT_TO_DECK)
+	e2:SetCondition(s.thcon)
+	e2:SetTarget(s.thtg)
+	e2:SetOperation(s.thop)
+	c:RegisterEffect(e2)
+	if not s.global_check then
+		s.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DESTROY)
+		ge1:SetOperation(s.descheck)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function s.descheck(e,tp,eg,ep,ev,re,r,rp)
+	for tc in aux.Next(eg) do
+		if tc:IsLocation(LOCATION_MZONE) and r&REASON_EFFECT>0 and Duel.GetFlagEffect(tc:GetControler(),id)==0 then
+			if re~=nil and re:GetHandler():IsType(TYPE_SPELL) or tc:GetReasonPlayer()==1-tc:GetControler() then
+				Duel.RegisterFlagEffect(tc:GetControler(),id,RESET_PHASE+PHASE_END,0,1)
+			end
+		end
+	end
+end
+function s.conditon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFlagEffect(tp,id)>0
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_BP_TWICE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	if Duel.GetTurnPlayer()==tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE) then
+		e1:SetLabel(Duel.GetTurnCount())
+		e1:SetCondition(s.bpcon)
+		e1:SetReset(RESET_PHASE+PHASE_BATTLE+RESET_SELF_TURN,2)
+	else
+		e1:SetReset(RESET_PHASE+PHASE_BATTLE+RESET_SELF_TURN,1)
+	end
+	Duel.RegisterEffect(e1,tp)
+end
+function s.bpcon(e)
+	return Duel.GetTurnCount()~=e:GetLabel()
+end
+function s.cfilter(c,tp)
+	return c:IsPreviousControler(tp) and c:IsType(TYPE_MONSTER)
+		and c:IsPreviousLocation(LOCATION_MZONE) and (c:IsFacedown() or c:IsLocation(LOCATION_DECK))
+end
+function s.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter,1,nil,tp)
+end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToHand() end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,e:GetHandler(),1,0,0)
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SendtoHand(c,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,c)
+	end
+end

--- a/scripts/QCDB-JP/c100212002.lua
+++ b/scripts/QCDB-JP/c100212002.lua
@@ -38,7 +38,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e4)
 	
 end
-s.lvup={57116033,id}
+s.lvup={id}
 function s.spfilter(c)
 	return (c:IsCode(57116033) or c:IsSetCard(0x3008) and c:IsType(TYPE_FUSION)) and c:IsFaceupEx() and c:IsAbleToRemoveAsCost()
 end

--- a/scripts/QCDB-JP/c100212002.lua
+++ b/scripts/QCDB-JP/c100212002.lua
@@ -1,0 +1,87 @@
+--羽翼栗子球 LV6
+local s,id,o=GetID()
+function s.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND+LOCATION_GRAVE)
+	e2:SetCondition(s.spcon)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(s.descon)
+	e3:SetCost(s.descost)
+	e3:SetTarget(s.destg)
+	e3:SetOperation(s.desop)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetType(EFFECT_TYPE_QUICK_O)
+	e4:SetCode(EVENT_CHAINING)
+	e4:SetCondition(s.descon2)
+	e4:SetTarget(s.destg2)
+	e4:SetOperation(s.desop2)
+	c:RegisterEffect(e4)
+	
+end
+s.lvup={57116033,id}
+function s.spfilter(c)
+	return (c:IsCode(57116033) or c:IsSetCard(0x3008)) and c:IsFaceupEx() and c:IsAbleToRemoveAsCost()
+end
+function s.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_GRAVE+LOCATION_ONFIELD+LOCATION_HAND,0,1,c)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_GRAVE+LOCATION_ONFIELD+LOCATION_HAND,0,1,1,c)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function s.descon(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=Duel.GetTurnPlayer()
+end
+function s.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=Duel.GetAttacker()
+	if chk==0 then return tc:IsDestructable() end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function s.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	if tc:IsRelateToBattle() and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,tc:GetBaseAttack(),REASON_EFFECT)
+	end
+end
+function s.descon2(e,tp,eg,ep,ev,re,r,rp)
+	return rp~=tp and re:GetHandler():IsOnField() and re:GetHandler():IsRelateToEffect(re) and re:IsActiveType(TYPE_MONSTER)
+end
+function s.destg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return re:GetHandler():IsDestructable() end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function s.desop2(e,tp,eg,ep,ev,re,r,rp)
+	local tc=re:GetHandler()
+	if tc:IsRelateToEffect(re) and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,tc:GetBaseAttack(),REASON_EFFECT)
+	end
+end

--- a/scripts/QCDB-JP/c100212002.lua
+++ b/scripts/QCDB-JP/c100212002.lua
@@ -64,25 +64,26 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=Duel.GetAttacker()
 	if chk==0 then return tc:IsDestructable() end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+	if math.max(0,tc:GetTextAttack())>0 then Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0) end
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetAttacker()
-	if tc:IsRelateToBattle() and Duel.Destroy(tc,REASON_EFFECT)>0 then
-		Duel.Damage(1-tp,tc:GetBaseAttack(),REASON_EFFECT)
+	if tc:IsRelateToBattle() and tc:IsLocation(LOCATION_MZONE) and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,math.max(0,tc:GetTextAttack()),REASON_EFFECT)
 	end
 end
 function s.descon2(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and re:GetHandler():IsOnField() and re:GetHandler():IsRelateToEffect(re) and re:IsActiveType(TYPE_MONSTER)
 end
 function s.destg2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return re:GetHandler():IsDestructable() end
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+	local tc=re:GetHandler()
+	if chk==0 then return tc:IsDestructable() end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+	if math.max(0,tc:GetTextAttack())>0 then Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0) end
 end
 function s.desop2(e,tp,eg,ep,ev,re,r,rp)
 	local tc=re:GetHandler()
-	if tc:IsRelateToEffect(re) and Duel.Destroy(tc,REASON_EFFECT)>0 then
-		Duel.Damage(1-tp,tc:GetBaseAttack(),REASON_EFFECT)
+	if tc:IsRelateToEffect(re) and tc:IsLocation(LOCATION_MZONE) and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,math.max(0,tc:GetTextAttack()),REASON_EFFECT)
 	end
 end

--- a/scripts/QCDB-JP/c100212002.lua
+++ b/scripts/QCDB-JP/c100212002.lua
@@ -14,6 +14,7 @@ function s.initial_effect(c)
 	e2:SetCode(EFFECT_SPSUMMON_PROC)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e2:SetRange(LOCATION_HAND+LOCATION_GRAVE)
+	e2:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
 	e2:SetCondition(s.spcon)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
@@ -39,7 +40,7 @@ function s.initial_effect(c)
 end
 s.lvup={57116033,id}
 function s.spfilter(c)
-	return (c:IsCode(57116033) or c:IsSetCard(0x3008)) and c:IsFaceupEx() and c:IsAbleToRemoveAsCost()
+	return (c:IsCode(57116033) or c:IsSetCard(0x3008) and c:IsType(TYPE_FUSION)) and c:IsFaceupEx() and c:IsAbleToRemoveAsCost()
 end
 function s.spcon(e,c)
 	if c==nil then return true end

--- a/scripts/QCDB-JP/c100212002.lua
+++ b/scripts/QCDB-JP/c100212002.lua
@@ -1,4 +1,4 @@
---羽翼栗子球 LV6
+--ハネクリボーLV6
 local s,id,o=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()

--- a/scripts/QCDB-JP/c100212003.lua
+++ b/scripts/QCDB-JP/c100212003.lua
@@ -61,7 +61,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		Duel.AdjustAll()
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
-		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+		if g:GetCount()>0 and c:IsLocation(LOCATION_MZONE) and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local sg=g:Select(tp,1,1,nil)

--- a/scripts/QCDB-JP/c100212003.lua
+++ b/scripts/QCDB-JP/c100212003.lua
@@ -1,4 +1,4 @@
---辉煌星之龙
+--輝ける星の竜
 local s,id,o=GetID()
 function s.initial_effect(c)
 	--spsummon
@@ -61,7 +61,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		Duel.AdjustAll()
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
-		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local sg=g:Select(tp,1,1,nil)

--- a/scripts/QCDB-JP/c100212003.lua
+++ b/scripts/QCDB-JP/c100212003.lua
@@ -1,0 +1,86 @@
+--辉煌星之龙
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
+	e1:SetCountLimit(1,id)
+	e1:SetCondition(s.spcon)
+	e1:SetTarget(s.sptg)
+	e1:SetOperation(s.spop)
+	c:RegisterEffect(e1)
+	--immune
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_BE_MATERIAL)
+	e2:SetProperty(EFFECT_FLAG_EVENT_PLAYER)
+	e2:SetCondition(s.indcon)
+	e2:SetOperation(s.indop)
+	c:RegisterEffect(e2)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return Duel.GetTurnPlayer()~=tp and (ph==PHASE_MAIN1 or ph==PHASE_MAIN2)
+end
+function s.filter(c,e,tp)
+	return c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and not Duel.IsPlayerAffectedByEffect(tp,59822133) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	g:AddCard(c)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
+end
+function s.spfilter(c,tuner)
+	return c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO) and c:IsSynchroSummonable(tuner)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) and tc:IsRelateToEffect(e) and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetValue(RESET_TURN_SET)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e2)
+		Duel.SpecialSummonComplete()
+		Duel.AdjustAll()
+		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
+		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=g:Select(tp,1,1,nil)
+			Duel.SynchroSummon(tp,sg:GetFirst(),c)
+		end
+	end
+end
+function s.indcon(e,tp,eg,ep,ev,re,r,rp)
+	return r==REASON_SYNCHRO and e:GetHandler():GetReasonCard():IsRace(RACE_DRAGON)
+end
+function s.indop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local rc=c:GetReasonCard()
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,1))
+	e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetValue(1)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+	rc:RegisterEffect(e1,true)
+end

--- a/scripts/QCDB-JP/c100212003.lua
+++ b/scripts/QCDB-JP/c100212003.lua
@@ -61,7 +61,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		Duel.AdjustAll()
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
-		if g:GetCount()>0 and c:IsLocation(LOCATION_MZONE) and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+		if g:GetCount()>0 and c:IsRelateToEffect(e) and c:IsControler(tp) and c:IsFaceup() and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local sg=g:Select(tp,1,1,nil)

--- a/scripts/QCDB-JP/old cards/002/c33776734.lua
+++ b/scripts/QCDB-JP/old cards/002/c33776734.lua
@@ -1,0 +1,81 @@
+--ハネクリボー LV9
+function c33776734.initial_effect(c)
+	c:SetUniqueOnField(1,0,33776734)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(33776734,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,33776734+EFFECT_COUNT_CODE_CHAIN)
+	e1:SetCondition(c33776734.spcon)
+	e1:SetTarget(c33776734.sptg)
+	e1:SetOperation(c33776734.spop)
+	c:RegisterEffect(e1)
+	--remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e2:SetTarget(c33776734.rmtarget)
+	e2:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e2)
+	--atk,def
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(EFFECT_SET_ATTACK)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetValue(c33776734.val)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_SET_DEFENSE)
+	c:RegisterEffect(e4)
+	if not c33776734.global_check then
+		c33776734.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		ge1:SetCode(EVENT_CHAINING)
+		ge1:SetOperation(c33776734.checkop1)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=ge1:Clone()
+		ge2:SetCode(EVENT_CHAIN_NEGATED)
+		ge2:SetOperation(c33776734.checkop2)
+		Duel.RegisterEffect(ge2,0)
+	end
+end
+c33776734.lvup={33776734}
+c33776734.lvdn={100212002}
+function c33776734.checkop1(e,tp,eg,ep,ev,re,r,rp)
+	if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) then
+		re:GetHandler():RegisterFlagEffect(33776734,RESET_EVENT+RESETS_STANDARD,0,1)
+	end
+end
+function c33776734.checkop2(e,tp,eg,ep,ev,re,r,rp)
+	if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) then
+		re:GetHandler():ResetFlagEffect(33776734)
+	end
+end
+function c33776734.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentChain()>=2
+end
+function c33776734.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c33776734.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+end
+function c33776734.rmtarget(e,c)
+	return c:IsFaceup() and c:GetFlagEffect(33776734)>0
+end
+function c33776734.val(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsType,c:GetControler(),0,LOCATION_GRAVE,nil,TYPE_SPELL)*500
+end

--- a/scripts/QCDB-JP/old cards/002/c98585345.lua
+++ b/scripts/QCDB-JP/old cards/002/c98585345.lua
@@ -1,0 +1,55 @@
+--ハネクリボー LV10
+function c98585345.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(98585345,0))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetHintTiming(TIMING_BATTLE_PHASE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c98585345.descon)
+	e2:SetCost(c98585345.descost)
+	e2:SetTarget(c98585345.destg)
+	e2:SetOperation(c98585345.desop)
+	c:RegisterEffect(e2)
+end
+c98585345.lvdn={33776734,100212002}
+function c98585345.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE)
+end
+function c98585345.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function c98585345.dfilter(c)
+	return c:IsAttackPos()
+end
+function c98585345.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c98585345.dfilter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c98585345.dfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function c98585345.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c98585345.dfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+	local dg=Duel.GetOperatedGroup()
+	local tc=dg:GetFirst()
+	local dam=0
+	while tc do
+		local atk=tc:GetTextAttack()
+		if atk<0 then atk=0 end
+		dam=dam+atk
+		tc=dg:GetNext()
+	end
+	Duel.Damage(1-tp,dam,REASON_EFFECT)
+end

--- a/scripts/TW01-JP/c100211053.lua
+++ b/scripts/TW01-JP/c100211053.lua
@@ -1,0 +1,117 @@
+--レアル・ジェネクス・チューリング
+--Scripted by zengsxing
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,id)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
+	e1:SetCondition(s.spcon)
+	e1:SetTarget(s.sptg)
+	e1:SetOperation(s.spop)
+	c:RegisterEffect(e1)
+	--synchro level
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_SYNCHRO_MATERIAL_CUSTOM)
+	e2:SetTarget(s.syntg)
+	e2:SetValue(1)
+	e2:SetOperation(s.synop)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(id)
+	e3:SetRange(LOCATION_MZONE)
+	c:RegisterEffect(e3)
+end
+function s.cardiansynlevel(c,sc)
+	if c:IsHasEffect(id) and sc:IsSetCard(0x2) then
+		return 3+(1<<16)
+	else
+		return c:GetSynchroLevel(sc)
+	end
+end
+function s.synfilter(c,syncard,tuner,f)
+	return c:IsFaceupEx() and c:IsCanBeSynchroMaterial(syncard,tuner) and (f==nil or f(c,syncard))
+end
+function s.syncheck(c,g,mg,tp,lv,syncard,minc,maxc)
+	g:AddCard(c)
+	local ct=g:GetCount()
+	local res=s.syngoal(g,tp,lv,syncard,minc,ct)
+		or (ct<maxc and mg:IsExists(s.syncheck,1,g,g,mg,tp,lv,syncard,minc,maxc))
+	g:RemoveCard(c)
+	return res
+end
+function s.syngoal(g,tp,lv,syncard,minc,ct)
+	return ct>=minc and Duel.GetLocationCountFromEx(tp,tp,g,syncard)>0
+		and (g:CheckWithSumEqual(Card.GetSynchroLevel,lv,ct,ct,syncard)
+			or g:CheckWithSumEqual(s.cardiansynlevel,lv,ct,ct,syncard))
+		and aux.MustMaterialCheck(g,tp,EFFECT_MUST_BE_SMATERIAL)
+end
+function s.syntg(e,syncard,f,min,max)
+	local minc=min+1
+	local maxc=max+1
+	local c=e:GetHandler()
+	local tp=syncard:GetControler()
+	local lv=syncard:GetLevel()
+	if lv<=c:GetLevel() and lv<=s.cardiansynlevel(c) then return false end
+	local g=Group.FromCards(c)
+	local mg=Duel.GetSynchroMaterial(tp):Filter(s.synfilter,c,syncard,c,f)
+	return mg:IsExists(s.syncheck,1,g,g,mg,tp,lv,syncard,minc,maxc)
+end
+function s.synop(e,tp,eg,ep,ev,re,r,rp,syncard,f,min,max)
+	local minc=min+1
+	local maxc=max+1
+	local c=e:GetHandler()
+	local lv=syncard:GetLevel()
+	local g=Group.FromCards(c)
+	local mg=Duel.GetSynchroMaterial(tp):Filter(s.synfilter,c,syncard,c,f)
+	for i=1,maxc do
+		local cg=mg:Filter(s.syncheck,g,g,mg,tp,lv,syncard,minc,maxc)
+		if cg:GetCount()==0 then break end
+		local minct=1
+		if s.syngoal(g,tp,lv,syncard,minc,i) then
+			minct=0
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
+		local sg=cg:Select(tp,minct,1,nil)
+		if sg:GetCount()==0 then break end
+		g:Merge(sg)
+	end
+	Duel.SetSynchroMaterial(g)
+end
+function s.spfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x2)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return Duel.GetTurnPlayer()~=tp and (ph==PHASE_MAIN1 or ph==PHASE_MAIN2) and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,0,tp,LOCATION_HAND+ LOCATION_EXTRA)
+end
+function s.syncfilter(c,tp)
+	return c:IsSetCard(0x2) and c:IsType(TYPE_SYNCHRO) and c:IsSynchroSummonable(nil)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+		Duel.AdjustAll()
+		if Duel.IsExistingMatchingCard(s.syncfilter,tp,LOCATION_EXTRA,0,1,nil,tp) and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local g=Duel.SelectMatchingCard(tp,s.syncfilter,tp,LOCATION_EXTRA,0,1,1,nil,tp)
+			Duel.SynchroSummon(tp,g:GetFirst(),nil)
+		end
+	end
+end

--- a/scripts/TW01-JP/c100211053.lua
+++ b/scripts/TW01-JP/c100211053.lua
@@ -1,5 +1,4 @@
 --レアル・ジェネクス・チューリング
---Scripted by zengsxing
 local s,id,o=GetID()
 function s.initial_effect(c)
 	--spsummon
@@ -107,7 +106,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
 		Duel.AdjustAll()
-		if Duel.IsExistingMatchingCard(s.syncfilter,tp,LOCATION_EXTRA,0,1,nil,tp) and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+		if Duel.IsExistingMatchingCard(s.syncfilter,tp,LOCATION_EXTRA,0,1,nil,tp) and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local g=Duel.SelectMatchingCard(tp,s.syncfilter,tp,LOCATION_EXTRA,0,1,1,nil,tp)


### PR DESCRIPTION
由于删除了之前的存储库，这里将之前没有被合并的卡进行了重投
包含真次世代图灵机员，羽翼栗子球 LV6，辉煌星之龙，几星霜
并对老卡羽翼栗子球 LV9，羽翼栗子球 LV10进行了修改，以适配等级下降