### PR TITLE
Fix 氷霊山の龍祖-ランセア Effect①-Condition 

### DIFF
--- a/scripts/TW01-JP/c100211001.lua
+++ b/scripts/TW01-JP/c100211001.lua
@@ -1,5 +1,4 @@
 --氷霊山の龍祖 ランセア
---Script by 蓝蓝
 local s,id,o=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
@@ -30,7 +29,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not eg:IsContains(e:GetHandler()) and eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
+	return eg:IsExists(Card.IsSummonPlayer,1,e:GetHandler(),1-tp)
 end
 function s.filter(c,e,tp)
 	return c:IsSetCard(0x2f) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
Like  [2250](https://github.com/Fluorohydride/ygopro-scripts/pull/2250)
对方同时把包含这张卡的多只怪兽特殊召唤到我方场上的场合，应该能发动①效果