### PR TITLE
fix レアル・ジェネクス・ウンディーネ

### DIFF
--- a/c100211052.lua
+++ b/c100211052.lua
@@ -1,0 +1,104 @@
+--レアル・ジェネクス・ウンディーネ
+--Scripted by Gong'E
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--change
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(s.cgcost)
+	e1:SetOperation(s.cgop)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(s.thcon)
+	e2:SetTarget(s.thtg)
+	e2:SetOperation(s.thop)
+	c:RegisterEffect(e2)
+end
+
+	--change
+function s.cgfilter(c,mc)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x2) and c:IsAbleToRemove() and not c:IsAttribute(mc:GetAttribute())
+end
+function s.cgcost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cgfilter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,s.cgfilter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler())
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+	e:SetLabelObject(g:GetFirst())
+end
+function s.cgop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=e:GetLabelObject()
+	local att=tc:GetAttribute()
+	if c:IsAttribute(att) then return end
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_ADD_ATTRIBUTE)
+		e1:SetValue(att)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	end
+	if c:IsFaceup() and tc:IsType(TYPE_TUNER) and not c:IsType(TYPE_TUNER) 
+	and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+		Duel.BreakEffect()
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e2:SetValue(TYPE_TUNER)
+		c:RegisterEffect(e2)
+	end
+end
+
+	--to hand
+function s.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x2) and c:IsType(TYPE_SYNCHRO)
+end
+function s.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function s.tgfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x2) and c:IsAbleToHand()
+end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.tgfilter(chkc) and chkc~=c end
+	if chk==0 then return Duel.IsExistingTarget(s.tgfilter,tp,LOCATION_GRAVE,0,1,c) and c:IsAbleToHand() end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+	local g1=Duel.SelectTarget(tp,s.tgfilter,tp,LOCATION_GRAVE,0,1,1,c)
+	local g2=Group.GetFirst(g1)
+	local g3=Duel.SetTargetCard(c)
+	local g=Group.FromCards(g2,g3)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,2,0,0)
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
+	if sg:GetCount()>=0 then
+		Duel.SendtoHand(sg,nil,REASON_EFFECT)
+		local e3=Effect.CreateEffect(e:GetHandler())
+		e3:SetType(EFFECT_TYPE_FIELD)
+		e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_SINGLE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+		e3:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+		e3:SetTarget(s.rmtarget)
+		e3:SetTargetRange(0xff,0xfe)
+		e3:SetValue(LOCATION_REMOVED)
+		e3:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e3,tp)
+	end
+end
+function s.rmtarget(e,c)
+	return c:GetOwner()==e:GetHandlerPlayer()
+end


### PR DESCRIPTION
修复真次世代水精灵以下问题：
①效果处理时已经拥有对象怪兽属性时，应该不能适用变调整效果。
②效果适用后，对面将原本持有者为自己的卡送入墓地时也应该除外，自己将原本持有者为对手的卡送入墓地时不应该除外。（礼物交换、DD乌鸦）